### PR TITLE
Fix Streaming Compression Flushing

### DIFF
--- a/packages/compress/src/response.ts
+++ b/packages/compress/src/response.ts
@@ -1,8 +1,8 @@
-import { isCompressionStreamAvailable } from "./runtime";
+import { isZlibAvailable } from "./runtime";
 import type { CompressionAlgorithm, CompressionOptions, Compressor } from "./types";
 
 async function guessCompressor(encoding: CompressionAlgorithm): Promise<Compressor> {
-  if (encoding === "br" || !isCompressionStreamAvailable) {
+  if (isZlibAvailable) {
     const { compressStream } = await import("./zlib/stream.js");
 
     return (input) => compressStream(input, encoding);

--- a/packages/compress/src/zlib/stream.ts
+++ b/packages/compress/src/zlib/stream.ts
@@ -17,8 +17,8 @@ const algorithms = {
 
 const defaultOptions = {
   br: { flush: constants.BROTLI_OPERATION_FLUSH, params: { [constants.BROTLI_PARAM_QUALITY]: 4 } },
-  gzip: { flush: constants.Z_PARTIAL_FLUSH },
-  deflate: { flush: constants.Z_PARTIAL_FLUSH },
+  gzip: { flush: constants.Z_SYNC_FLUSH },
+  deflate: { flush: constants.Z_SYNC_FLUSH },
 } as const;
 
 export function compressStream<C extends CompressionAlgorithm, O extends Parameters<(typeof algorithms)[C]>[0]>(

--- a/packages/compress/src/zlib/stream.ts
+++ b/packages/compress/src/zlib/stream.ts
@@ -16,9 +16,9 @@ const algorithms = {
 } as const;
 
 const defaultOptions = {
-  br: { params: { [constants.BROTLI_PARAM_QUALITY]: 4 } },
-  gzip: {},
-  deflate: {},
+  br: { flush: constants.BROTLI_OPERATION_FLUSH, params: { [constants.BROTLI_PARAM_QUALITY]: 4 } },
+  gzip: { flush: constants.Z_PARTIAL_FLUSH },
+  deflate: { flush: constants.Z_PARTIAL_FLUSH },
 } as const;
 
 export function compressStream<C extends CompressionAlgorithm, O extends Parameters<(typeof algorithms)[C]>[0]>(


### PR DESCRIPTION
This PR addresses two issues preventing proper streaming compression:

1. Prefer zlib over WHATWG API when available: The WHATWG Compression API only flushes compressed data when the entire stream closes, making it incompatible with progressive streaming needs. Zlib provides the necessary control mechanisms for incremental flushing.
2. Add explicit flush flags: Implemented Z_SYNC_FLUSH for gzip/deflate and BROTLI_OPERATION_FLUSH for brotli to ensure compressed data is flushed at appropriate synchronization points during streaming.

Together, these changes enable compressed content to stream progressively to clients, fixing React Server Components, progressive hydration, and other streaming-first features that were previously broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the selection logic for compression algorithms to improve consistency.
  - Enhanced compression configurations by fine-tuning flush settings for more efficient stream handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->