### PR TITLE
fix(express): avoid duplicate set-cookie in response transformers

### DIFF
--- a/.changeset/tough-lands-sin.md
+++ b/.changeset/tough-lands-sin.md
@@ -4,4 +4,4 @@
 "@universal-middleware/node": patch
 ---
 
-Fix duplicated Set-Cookie headers when Express response transformers mirror cookies already set on the response.
+fix: duplicated Set-Cookie headers when Express response transformers mirror cookies already set on the response.

--- a/.changeset/tough-lands-sin.md
+++ b/.changeset/tough-lands-sin.md
@@ -1,0 +1,7 @@
+---
+"@universal-middleware/express": patch
+"@universal-middleware/core": patch
+"@universal-middleware/node": patch
+---
+
+Fix duplicated Set-Cookie headers when Express response transformers mirror cookies already set on the response.

--- a/packages/adapter-express/tests/entry-express.ts
+++ b/packages/adapter-express/tests/entry-express.ts
@@ -19,6 +19,16 @@ const { default: express } = await (process.env.EXPRESS_V4 ? import("express4") 
 const app = express() as import("express").Express;
 
 app.use(helmet());
+app.use((req, res, next) => {
+  if (req.path === "/") {
+    res.cookie("express-cookie-example", "res-cookie", {
+      httpOnly: true,
+      maxAge: 60 * 60 * 1000,
+      sameSite: "lax",
+    });
+  }
+  next();
+});
 
 const TEST_CASE = process.env.TEST_CASE;
 

--- a/packages/adapter-express/tests/express.spec.ts
+++ b/packages/adapter-express/tests/express.spec.ts
@@ -1,4 +1,6 @@
+import { ServerResponse } from "node:http";
 import { type Run, runTests } from "@universal-middleware/tests";
+import { setResponseHeaders } from "@universal-middleware/node";
 import * as vitest from "vitest";
 
 let port = 3100;
@@ -71,5 +73,49 @@ runTests(runs, {
     // added by helmet
     vitest.expect(response.headers.has("content-security-policy")).toBe(true);
     vitest.expect(response.headers.has("x-xss-protection")).toBe(true);
+    vitest
+      .expect(response.headers.getSetCookie().filter((cookie) => cookie.startsWith("express-cookie-example=")))
+      .toHaveLength(1);
   },
+});
+
+vitest.describe("setResponseHeaders mirror mode", () => {
+  vitest.test("appends set-cookie headers when mirror mode is disabled", () => {
+    const nodeResponse = new ServerResponse({} as never);
+    nodeResponse.setHeader("set-cookie", ["express-cookie=old"]);
+    const response = new Response(null, {
+      headers: [["set-cookie", "universal-cookie=new"]],
+    });
+
+    setResponseHeaders(response, nodeResponse);
+
+    vitest.expect(nodeResponse.getHeader("set-cookie")).toEqual(["express-cookie=old", "universal-cookie=new"]);
+  });
+
+  vitest.test("replaces multiple existing set-cookie headers", () => {
+    const nodeResponse = new ServerResponse({} as never);
+    nodeResponse.setHeader("set-cookie", ["express-cookie=old", "other-express-cookie=old"]);
+    const response = new Response(null, {
+      headers: [
+        ["set-cookie", "universal-cookie=new"],
+        ["set-cookie", "other-universal-cookie=new"],
+      ],
+    });
+
+    setResponseHeaders(response, nodeResponse, true);
+
+    vitest
+      .expect(nodeResponse.getHeader("set-cookie"))
+      .toEqual(["universal-cookie=new", "other-universal-cookie=new"]);
+  });
+
+  vitest.test("removes existing set-cookie headers when mirrored response omits them", () => {
+    const nodeResponse = new ServerResponse({} as never);
+    nodeResponse.setHeader("set-cookie", ["express-cookie=old"]);
+    const response = new Response(null);
+
+    setResponseHeaders(response, nodeResponse, true);
+
+    vitest.expect(nodeResponse.hasHeader("set-cookie")).toBe(false);
+  });
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -62,7 +62,7 @@ export function nodeHeadersToWeb(nodeHeaders: OutgoingHttpHeaders): Headers {
 }
 
 function normalizeHttpHeader(value: string | number | undefined): string {
-  return (value as string) || "";
+  return value === undefined ? "" : String(value);
 }
 
 export function url(request: { url: string; [urlSymbol]?: URL }): URL {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -47,16 +47,21 @@ export function nodeHeadersToWeb(nodeHeaders: OutgoingHttpHeaders): Headers {
 
   const keys = Object.keys(nodeHeaders);
   for (const key of keys) {
-    headers.push([key, normalizeHttpHeader(nodeHeaders[key])]);
+    const value = nodeHeaders[key];
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.push([key, item]);
+      }
+    } else {
+      headers.push([key, normalizeHttpHeader(value)]);
+    }
   }
 
   return new Headers(headers);
 }
 
-function normalizeHttpHeader(value: string | string[] | number | undefined): string {
-  if (Array.isArray(value)) {
-    return value.join(", ");
-  }
+function normalizeHttpHeader(value: string | number | undefined): string {
   return (value as string) || "";
 }
 

--- a/packages/core/test/cookies.test.ts
+++ b/packages/core/test/cookies.test.ts
@@ -150,4 +150,12 @@ describe("nodeHeadersToWeb", () => {
 
     expect(headers.getSetCookie()).toEqual(["foo=bar", "foo2=bar2"]);
   });
+
+  test("keeps custom array headers readable as comma-joined values", () => {
+    const headers = nodeHeadersToWeb({
+      "x-custom-vary": ["Accept-Encoding", "Origin"],
+    });
+
+    expect(headers.get("x-custom-vary")).toBe("Accept-Encoding, Origin");
+  });
 });

--- a/packages/core/test/cookies.test.ts
+++ b/packages/core/test/cookies.test.ts
@@ -1,6 +1,7 @@
 import { describe } from "node:test";
 import { expect, test } from "vitest";
 import { deleteCookie, getCookie, getCookies, setCookie } from "../src/cookies/index";
+import { nodeHeadersToWeb } from "../src/utils";
 
 describe("getCookie", () => {
   test("simple cookie", () => {
@@ -138,5 +139,15 @@ describe("deleteCookie", () => {
     expect(response.headers.getSetCookie()).toEqual(["foo=bar", "foo2=bar2"]);
     deleteCookie(response, "foo");
     expect(response.headers.getSetCookie()).toEqual(["foo2=bar2"]);
+  });
+});
+
+describe("nodeHeadersToWeb", () => {
+  test("preserves multiple set-cookie headers", () => {
+    const headers = nodeHeadersToWeb({
+      "set-cookie": ["foo=bar", "foo2=bar2"],
+    });
+
+    expect(headers.getSetCookie()).toEqual(["foo=bar", "foo2=bar2"]);
   });
 });

--- a/packages/node/src/response.ts
+++ b/packages/node/src/response.ts
@@ -87,6 +87,12 @@ export function responseAdapter(nodeResponse: ServerResponse, bodyInit?: BodyIni
   });
 }
 
+/**
+ * Applies Web Response headers to a Node.js response.
+ *
+ * In mirror mode, the Web Response headers replace the Node.js response header snapshot.
+ * Otherwise, Set-Cookie is appended to preserve existing Node.js cookies when sending a fresh response.
+ */
 export function setResponseHeaders(fetchResponse: Response, nodeResponse: ServerResponse, mirror = false) {
   nodeResponse.statusCode = fetchResponse.status;
   if (fetchResponse.statusText) {
@@ -96,8 +102,17 @@ export function setResponseHeaders(fetchResponse: Response, nodeResponse: Server
   const nodeResponseHeaders = new Set(Object.keys(nodeResponse.getHeaders()));
 
   const setCookie = fetchResponse.headers.getSetCookie();
-  for (const cookie of setCookie) {
-    nodeResponse.appendHeader("set-cookie", cookie);
+  if (mirror) {
+    // When omitted in mirror mode, existing Set-Cookie headers remain in nodeResponseHeaders
+    // and are removed by the cleanup below.
+    if (setCookie.length > 0) {
+      nodeResponse.setHeader("set-cookie", setCookie);
+      nodeResponseHeaders.delete("set-cookie");
+    }
+  } else {
+    for (const cookie of setCookie) {
+      nodeResponse.appendHeader("set-cookie", cookie);
+    }
   }
 
   fetchResponse.headers.forEach((value, key) => {


### PR DESCRIPTION
Fix duplicated Set-Cookie in Express response transformers.

Close #312 

## Summary

- Fix `setResponseHeaders(..., mirror=true)` so `Set-Cookie` headers are replaced as part of the mirrored response snapshot instead of appended back onto the same Express response.
- Preserve array-valued Node headers as repeated Web `Headers` entries, so multiple `Set-Cookie` values survive Node-to-Web conversion.
- Add focused regression coverage for `res.cookie()` followed by a universal response transformer.

## Cause

The Express response-transform path wraps the live Express response. When headers are about to be sent, it creates a Web `Response` from the current Node response with `responseAdapter(nodeResponse, reader1)`. That Web `Response` includes headers already set by Express middleware, including cookies from `res.cookie()`.

After universal response transformers run, the adapter mirrors the transformed Web `Response` back onto the same Node response with `setResponseHeaders(response, nodeResponse, true)`. `setResponseHeaders` always appended `Set-Cookie`, which is correct for a fresh response send but wrong for mirroring an already-copied response snapshot. The copied cookie was appended to the response that already owned it, producing duplicates.

## Solution

`setResponseHeaders` now treats `mirror=true` as replacement semantics for `Set-Cookie`:

- non-mirror mode keeps appending cookies to preserve existing fresh-response behavior;
- mirror mode replaces existing cookies with the Web `Response` cookies;
- mirror mode removes existing cookies if the mirrored Web `Response` omits `Set-Cookie`.

`nodeHeadersToWeb` now expands array-valued Node headers into repeated Web header entries instead of joining arrays with `", "`. This is part of the same Express transformer path: `responseAdapter` reads `nodeResponse.getHeaders()` through `nodeHeadersToWeb` before `setResponseHeaders(..., mirror=true)` mirrors the result back. Without this, multiple cookies already set on the Express response would be collapsed before the mirror step can replace them correctly.

## Tests

- `packages/adapter-express/tests/entry-express.ts` sets an Express cookie on `/` before the universal middleware/handler flow.
- `packages/adapter-express/tests/express.spec.ts` asserts that cookie appears exactly once after the response transformer runs.
- `packages/adapter-express/tests/express.spec.ts` also covers the key `setResponseHeaders` cookie contracts: default append, mirror replacement, and mirror removal.
- `packages/core/test/cookies.test.ts` covers `nodeHeadersToWeb` preserving multiple `Set-Cookie` values while keeping custom array headers readable as comma-joined values.

## Validation

I verified this change with:

- `pnpm install`
- `pnpm run build`
- `pnpm --filter @universal-middleware/core test`
- `pnpm --filter @universal-middleware/express test`
- `pnpm run test:typecheck`
- `pnpm exec biome lint packages/adapter-express/tests/entry-express.ts packages/adapter-express/tests/express.spec.ts packages/core/src/utils.ts packages/core/test/cookies.test.ts packages/node/src/response.ts`
- `pnpm run lint`

`pnpm run lint` exits successfully but reports 5 unrelated pre-existing warnings outside the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Middleware that sets an example cookie on root requests.

* **Tests**
  * Added and expanded tests for cookie handling and response header behavior, including mirror-mode scenarios.

* **Improvements**
  * Improved handling of multiple Set-Cookie and array-style headers; mirror mode to align Node response headers with fetch/Web responses.

* **Bug Fixes**
  * Fixed duplicated Set-Cookie header issues when responses are mirrored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->