### PR TITLE
fix(express): propagate cancel event

### DIFF
--- a/.changeset/beige-tables-sink.md
+++ b/.changeset/beige-tables-sink.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/express": patch
+---
+
+fix: propagate cancel event

--- a/packages/adapter-express/src/utils.ts
+++ b/packages/adapter-express/src/utils.ts
@@ -38,15 +38,34 @@ export type WebHandler<InContext extends Universal.Context = Universal.Context, 
  */
 export function connectToWeb(handler: ConnectMiddleware | ConnectMiddlewareBoolean): WebHandler {
   return async (request: Request, _context, runtime): Promise<Response | undefined> => {
-    const req: IncomingMessage =
-      runtime && "req" in runtime && runtime.req
-        ? runtime.req
-        : // biome-ignore lint/suspicious/noExplicitAny: srvx request
-          ((request as any).runtime?.node?.req ?? createIncomingMessage(request));
+    const realReq: IncomingMessage | undefined =
+      // biome-ignore lint/suspicious/noExplicitAny: srvx request
+      (runtime && "req" in runtime && runtime.req) || (request as any).runtime?.node?.req;
+    const req: IncomingMessage = realReq ?? createIncomingMessage(request);
     const { res, onReadable } = createServerResponse(req);
+
+    // On the synthetic path (no real Node req/res backing the request) nothing wires
+    // client disconnect to the handler. Forward the incoming `AbortSignal` so the
+    // downstream request's signal fires and in-flight work can stop. On the real-Node
+    // path the underlying server already handles aborts, so we leave it untouched.
+    const signal = !realReq ? request.signal : undefined;
+    const onAbort = () => {
+      // `createRequestAdapter` ties the downstream request's AbortController to `res`'s
+      // "close" event; a socketless `ServerResponse` does not emit it on `destroy()`,
+      // so emit it explicitly to make the handler's `request.signal` fire.
+      if (!res.writableEnded) res.emit("close");
+      req.destroy?.();
+    };
 
     // biome-ignore lint/suspicious/noAsyncPromiseExecutor: ignored
     return new Promise<Response | undefined>(async (resolve, reject) => {
+      const cleanup = () => signal?.removeEventListener("abort", onAbort);
+
+      if (signal) {
+        if (signal.aborted) onAbort();
+        else signal.addEventListener("abort", onAbort, { once: true });
+      }
+
       onReadable(({ readable, headers, statusCode }) => {
         const responseBody: ReadableStream = statusCodesWithoutBody.includes(statusCode)
           ? null
@@ -55,6 +74,7 @@ export function connectToWeb(handler: ConnectMiddleware | ConnectMiddlewareBoole
               (ReadableStream as any).from(readable)
             : // biome-ignore lint/suspicious/noExplicitAny: definition clash between Web and Node
               (Readable.toWeb(readable) as any);
+        cleanup();
         resolve(
           new Response(responseBody, {
             status: statusCode,
@@ -64,6 +84,7 @@ export function connectToWeb(handler: ConnectMiddleware | ConnectMiddlewareBoole
       });
 
       const next = (error?: unknown) => {
+        cleanup();
         if (error) {
           reject(error instanceof Error ? error : new Error(String(error)));
         } else {
@@ -76,6 +97,7 @@ export function connectToWeb(handler: ConnectMiddleware | ConnectMiddlewareBoole
 
         if (handled === false) {
           res.destroy();
+          cleanup();
           resolve(undefined);
         }
       } catch (e) {
@@ -95,11 +117,29 @@ export function createIncomingMessage(request: Request): IncomingMessage {
   // biome-ignore lint/suspicious/noExplicitAny: ignored
   const body = request.body ? Readable.fromWeb(request.body as any) : Readable.from([]);
 
+  // Frameworks layered on top of `IncomingMessage` (e.g. Express) read connection
+  // metadata off `req.socket` — `req.protocol`/`req.secure` use `socket.encrypted`,
+  // `req.ip`/`req.ips` use `socket.remoteAddress`. A synthetic request has no real
+  // socket, so provide a minimal stub to avoid `Cannot read properties of undefined`.
+  const socket = {
+    encrypted: parsedUrl.protocol === "https:",
+    remoteAddress: undefined,
+    remotePort: undefined,
+    localAddress: undefined,
+    localPort: undefined,
+  };
+
   return Object.assign(body, {
     url: pathnameAndQuery,
     method: request.method,
     headers: Object.fromEntries(request.headers),
-  }) as IncomingMessage;
+    httpVersion: "1.1",
+    httpVersionMajor: 1,
+    httpVersionMinor: 1,
+    socket,
+    // legacy alias still consulted by some middlewares
+    connection: socket,
+  }) as unknown as IncomingMessage;
 }
 
 /**

--- a/packages/adapter-express/src/utils.ts
+++ b/packages/adapter-express/src/utils.ts
@@ -41,42 +41,24 @@ export function connectToWeb(handler: ConnectMiddleware | ConnectMiddlewareBoole
     const realReq: IncomingMessage | undefined =
       // biome-ignore lint/suspicious/noExplicitAny: srvx request
       (runtime && "req" in runtime && runtime.req) || (request as any).runtime?.node?.req;
-    const req: IncomingMessage = realReq ?? createIncomingMessage(request);
+    const req = realReq ?? createIncomingMessage(request);
     const { res, onReadable } = createServerResponse(req);
 
-    // On the synthetic path (no real Node req/res backing the request) nothing wires
-    // client disconnect to the handler. Forward the incoming `AbortSignal` so the
-    // downstream request's signal fires and in-flight work can stop. On the real-Node
-    // path the underlying server already handles aborts, so we leave it untouched.
-    const signal = !realReq ? request.signal : undefined;
-    const onAbort = () => {
-      // `createRequestAdapter` ties the downstream request's AbortController to `res`'s
-      // "close" event; a socketless `ServerResponse` does not emit it on `destroy()`,
-      // so emit it explicitly to make the handler's `request.signal` fire.
-      if (!res.writableEnded) res.emit("close");
-      req.destroy?.();
-    };
+    // A real server wires client disconnect to the request itself; a synthetic req/res does
+    // not, so bridge the incoming abort to the handler while the response is in flight.
+    const stopForwardingAbort = realReq ? undefined : forwardAbort(request.signal, req, res);
 
     // biome-ignore lint/suspicious/noAsyncPromiseExecutor: ignored
     return new Promise<Response | undefined>(async (resolve, reject) => {
-      const cleanup = () => signal?.removeEventListener("abort", onAbort);
-
-      if (signal) {
-        if (signal.aborted) onAbort();
-        else signal.addEventListener("abort", onAbort, { once: true });
-      }
-
       onReadable(({ readable, headers, statusCode }) => {
-        const responseBody: ReadableStream = statusCodesWithoutBody.includes(statusCode)
-          ? null
-          : "from" in ReadableStream
-            ? // biome-ignore lint/suspicious/noExplicitAny: definition clash between Web and Node
-              (ReadableStream as any).from(readable)
-            : // biome-ignore lint/suspicious/noExplicitAny: definition clash between Web and Node
-              (Readable.toWeb(readable) as any);
-        cleanup();
+        const hasBody = !statusCodesWithoutBody.includes(statusCode);
+        // Keep forwarding aborts until a streaming body has fully flushed, then stop.
+        if (stopForwardingAbort) {
+          if (hasBody) readable.once("close", stopForwardingAbort);
+          else stopForwardingAbort();
+        }
         resolve(
-          new Response(responseBody, {
+          new Response(hasBody ? toWebStream(readable) : null, {
             status: statusCode,
             headers: flattenHeaders(headers),
           }),
@@ -84,7 +66,7 @@ export function connectToWeb(handler: ConnectMiddleware | ConnectMiddlewareBoole
       });
 
       const next = (error?: unknown) => {
-        cleanup();
+        stopForwardingAbort?.();
         if (error) {
           reject(error instanceof Error ? error : new Error(String(error)));
         } else {
@@ -97,7 +79,7 @@ export function connectToWeb(handler: ConnectMiddleware | ConnectMiddlewareBoole
 
         if (handled === false) {
           res.destroy();
-          cleanup();
+          stopForwardingAbort?.();
           resolve(undefined);
         }
       } catch (e) {
@@ -112,33 +94,17 @@ export function connectToWeb(handler: ConnectMiddleware | ConnectMiddlewareBoole
  * @beta
  */
 export function createIncomingMessage(request: Request): IncomingMessage {
-  const parsedUrl = new URL(request.url, "http://localhost");
-  const pathnameAndQuery = (parsedUrl.pathname || "") + (parsedUrl.search || "");
-  // biome-ignore lint/suspicious/noExplicitAny: ignored
+  const url = new URL(request.url, "http://localhost");
+  // biome-ignore lint/suspicious/noExplicitAny: Web/Node stream type clash
   const body = request.body ? Readable.fromWeb(request.body as any) : Readable.from([]);
 
-  // Frameworks layered on top of `IncomingMessage` (e.g. Express) read connection
-  // metadata off `req.socket` — `req.protocol`/`req.secure` use `socket.encrypted`,
-  // `req.ip`/`req.ips` use `socket.remoteAddress`. A synthetic request has no real
-  // socket, so provide a minimal stub to avoid `Cannot read properties of undefined`.
-  const socket = {
-    encrypted: parsedUrl.protocol === "https:",
-    remoteAddress: undefined,
-    remotePort: undefined,
-    localAddress: undefined,
-    localPort: undefined,
-  };
-
+  // Express reads connection metadata off `req.socket` (e.g. `req.protocol` -> `socket.encrypted`);
+  // a synthetic request has no socket, so stub the field it reads to avoid a throw.
   return Object.assign(body, {
-    url: pathnameAndQuery,
+    url: url.pathname + url.search,
     method: request.method,
     headers: Object.fromEntries(request.headers),
-    httpVersion: "1.1",
-    httpVersionMajor: 1,
-    httpVersionMinor: 1,
-    socket,
-    // legacy alias still consulted by some middlewares
-    connection: socket,
+    socket: { encrypted: url.protocol === "https:" },
   }) as unknown as IncomingMessage;
 }
 
@@ -209,6 +175,39 @@ export function createServerResponse(incomingMessage: IncomingMessage) {
     res,
     onReadable,
   };
+}
+
+/**
+ * Bridges a web `AbortSignal` to a synthetic Node `req`/`res` and returns a stop function.
+ *
+ * `createRequestAdapter` derives the handler's `request.signal` from `res`'s "close" event,
+ * which a socketless `ServerResponse` never emits on its own — so emit it explicitly.
+ */
+function forwardAbort(signal: AbortSignal, req: IncomingMessage, res: ServerResponse): () => void {
+  let active = true;
+  const abort = () => {
+    if (!active) return;
+    active = false;
+    res.emit("close");
+    req.destroy();
+  };
+  // An already-aborted signal must wait for the handler to register its "close" listener,
+  // which it does synchronously once invoked.
+  if (signal.aborted) queueMicrotask(abort);
+  else signal.addEventListener("abort", abort, { once: true });
+  return () => {
+    active = false;
+    signal.removeEventListener("abort", abort);
+  };
+}
+
+function toWebStream(readable: Readable): ReadableStream {
+  // `ReadableStream.from` is unavailable on some runtimes/older Node versions.
+  return "from" in ReadableStream
+    ? // biome-ignore lint/suspicious/noExplicitAny: Web/Node stream type clash
+      (ReadableStream as any).from(readable)
+    : // biome-ignore lint/suspicious/noExplicitAny: Web/Node stream type clash
+      (Readable.toWeb(readable) as any);
 }
 
 function flattenHeaders(headers: OutgoingHttpHeaders): [string, string][] {

--- a/packages/adapter-express/tests/connect-to-web.spec.ts
+++ b/packages/adapter-express/tests/connect-to-web.spec.ts
@@ -1,0 +1,248 @@
+import type { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
+import type { RuntimeAdapterTarget, UniversalHandler } from "@universal-middleware/core";
+import express from "express";
+import { describe, expect, it } from "vitest";
+import { connectToWeb, createHandler, createIncomingMessage } from "../src/index.js";
+
+// In-process tests for `connectToWeb` driving a full Express app over the
+// synthetic (no `runtime.node`) path — the bridge `@vikejs/express` relies on.
+
+type Factory = () => UniversalHandler;
+
+function appFrom(factory: Factory) {
+  const app = express();
+  app.all("/t", createHandler(factory)());
+  const fh = connectToWeb(app);
+  return (request: Request) => Promise.resolve(fh(request));
+}
+
+// Asserts the bridge produced a Response (instead of falling through to next())
+// and narrows the type so the assertions below don't need non-null operators.
+function defined(res: Response | undefined): Response {
+  expect(res).toBeInstanceOf(Response);
+  return res as Response;
+}
+
+// `duplex` is required for streaming request bodies but is missing from the DOM
+// `RequestInit` type shipped with @types/node's lib here.
+function streamingRequest(url: string, init: RequestInit & { body: BodyInit }): Request {
+  return new Request(url, { ...init, duplex: "half" } as RequestInit);
+}
+
+describe("connectToWeb (synthetic path) — body & basics", () => {
+  it("reads a POST JSON body and echoes it", async () => {
+    const fh = appFrom(() => async (request) => {
+      const data = await request.json();
+      return Response.json({ ok: true, echo: data });
+    });
+    const res = defined(
+      await fh(
+        new Request("http://localhost/t", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ text: "hello" }),
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, echo: { text: "hello" } });
+  });
+
+  it("handles a GET request with no body", async () => {
+    const fh = appFrom(() => async (request) => {
+      const n = new URL(request.url).searchParams.get("n");
+      return new Response(`n=${n}`);
+    });
+    const res = defined(await fh(new Request("http://localhost/t?n=42")));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("n=42");
+  });
+
+  it("returns undefined when the connect handler calls next() without responding", async () => {
+    const app = express();
+    app.use("/t", (_req, _res, next) => next());
+    const res = await connectToWeb(app)(new Request("http://localhost/t"));
+    expect(res).toBeUndefined();
+  });
+});
+
+describe("connectToWeb (synthetic path) — Express connection metadata (socket stub)", () => {
+  it("does not throw on req.protocol / req.secure (http)", async () => {
+    const fh = appFrom(() => async (_request, _ctx, runtime) => {
+      const req = (runtime as { req: express.Request }).req;
+      return Response.json({ protocol: req.protocol, secure: req.secure });
+    });
+    const res = defined(await fh(new Request("http://localhost/t")));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ protocol: "http", secure: false });
+  });
+
+  it("reports https when the request URL is https", async () => {
+    const fh = appFrom(() => async (_request, _ctx, runtime) => {
+      const req = (runtime as { req: express.Request }).req;
+      return Response.json({ protocol: req.protocol, secure: req.secure });
+    });
+    const res = defined(await fh(new Request("https://localhost/t")));
+    expect(await res.json()).toEqual({ protocol: "https", secure: true });
+  });
+
+  it("does not throw on req.ip", async () => {
+    const fh = appFrom(() => async (_request, _ctx, runtime) => {
+      const req = (runtime as { req: express.Request }).req;
+      return new Response(String(req.ip ?? "undefined"));
+    });
+    const res = defined(await fh(new Request("http://localhost/t")));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("connectToWeb (synthetic path) — responses", () => {
+  it("preserves multiple Set-Cookie headers", async () => {
+    const fh = appFrom(
+      () => async () =>
+        new Response("ok", {
+          status: 200,
+          headers: [
+            ["set-cookie", "a=1; Path=/"],
+            ["set-cookie", "b=2; Path=/"],
+          ],
+        }),
+    );
+    const res = defined(await fh(new Request("http://localhost/t")));
+    expect(res.headers.getSetCookie()).toEqual(["a=1; Path=/", "b=2; Path=/"]);
+  });
+
+  it("preserves a 302 redirect with its Location", async () => {
+    const fh = appFrom(() => async () => Response.redirect("http://localhost/next", 302));
+    const res = defined(await fh(new Request("http://localhost/t")));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("http://localhost/next");
+  });
+
+  it("returns a 204 with no body", async () => {
+    const fh = appFrom(() => async () => new Response(null, { status: 204 }));
+    const res = defined(await fh(new Request("http://localhost/t")));
+    expect(res.status).toBe(204);
+    expect(res.body).toBeNull();
+  });
+
+  it("streams a chunked response without buffering it all first", async () => {
+    const fh = appFrom(() => async () => {
+      const enc = new TextEncoder();
+      let i = 0;
+      const stream = new ReadableStream<Uint8Array>({
+        pull(c) {
+          if (i >= 4) return c.close();
+          c.enqueue(enc.encode(`chunk${i++};`));
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/plain" } });
+    });
+    const res = defined(await fh(new Request("http://localhost/t")));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("chunk0;chunk1;chunk2;chunk3;");
+  });
+});
+
+describe("connectToWeb (synthetic path) — large body is streamed, not buffered", () => {
+  it("round-trips a large request body byte-for-byte", async () => {
+    const fh = appFrom(
+      () => async (request) =>
+        // echo the request body straight back as the response body (no buffering on our side)
+        new Response(request.body, { headers: { "content-type": "application/octet-stream" } }),
+    );
+    const CHUNK = 1 << 20; // 1 MiB
+    const COUNT = 32; // 32 MiB total
+    let sent = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(c) {
+        if (sent >= COUNT) return c.close();
+        const buf = new Uint8Array(CHUNK);
+        buf.fill(sent & 0xff);
+        c.enqueue(buf);
+        sent++;
+      },
+    });
+    const res = defined(await fh(streamingRequest("http://localhost/t", { method: "POST", body })));
+    expect(res.status).toBe(200);
+    let received = 0;
+    const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.length;
+    }
+    expect(received).toBe(CHUNK * COUNT);
+  });
+});
+
+describe("connectToWeb (synthetic path) — abort propagation", () => {
+  it("fires the handler's request.signal when the incoming request is aborted", async () => {
+    let signalFired = false;
+    const fh = appFrom(() => async (request) => {
+      await new Promise<void>((resolve) => {
+        request.signal.addEventListener("abort", () => {
+          signalFired = true;
+          resolve();
+        });
+        setTimeout(resolve, 2000);
+      });
+      return new Response("done");
+    });
+
+    const ctrl = new AbortController();
+    // a body that never ends, so the request stays in-flight until aborted
+    const body = new ReadableStream({ pull() {} });
+    const pending = fh(streamingRequest("http://localhost/t", { method: "POST", body, signal: ctrl.signal })).catch(
+      () => undefined,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    ctrl.abort();
+    await new Promise((r) => setTimeout(r, 100));
+    await pending;
+    expect(signalFired).toBe(true);
+  });
+});
+
+describe("connectToWeb — real-Node path uses the provided req/res", () => {
+  it("uses runtime.req instead of synthesizing an IncomingMessage", async () => {
+    // A real-ish Node IncomingMessage carrying the body. connectToWeb must use it
+    // (via the runtime.req branch) rather than calling createIncomingMessage.
+    const realReq = Object.assign(Readable.from([Buffer.from(JSON.stringify({ from: "realNode" }))]), {
+      url: "/t",
+      method: "POST",
+      headers: { "content-type": "application/json", host: "localhost" },
+      socket: { encrypted: false, remoteAddress: "203.0.113.7" },
+    }) as unknown as IncomingMessage;
+
+    const app = express();
+    app.all(
+      "/t",
+      createHandler(
+        (): UniversalHandler => async (request) => Response.json({ ok: true, echo: await request.json() }),
+      )(),
+    );
+
+    const runtime = { req: realReq } as unknown as RuntimeAdapterTarget<unknown>;
+    const res = defined(
+      await connectToWeb(app)(new Request("http://localhost/t", { method: "POST" }), undefined, runtime),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, echo: { from: "realNode" } });
+  });
+});
+
+describe("createIncomingMessage", () => {
+  it("builds an IncomingMessage with a socket stub and parsed url/method/headers", () => {
+    const req = createIncomingMessage(
+      new Request("https://localhost/a/b?x=1", { method: "PUT", headers: { "x-test": "1" } }),
+    );
+    expect(req.url).toBe("/a/b?x=1");
+    expect(req.method).toBe("PUT");
+    expect(req.headers["x-test"]).toBe("1");
+    // socket stub present so Express getters don't throw
+    expect(req.socket).toBeDefined();
+    expect((req.socket as unknown as { encrypted: boolean }).encrypted).toBe(true);
+  });
+});

--- a/packages/adapter-express/tests/connect-to-web.spec.ts
+++ b/packages/adapter-express/tests/connect-to-web.spec.ts
@@ -203,6 +203,68 @@ describe("connectToWeb (synthetic path) — abort propagation", () => {
     await pending;
     expect(signalFired).toBe(true);
   });
+
+  it("fires the handler's signal when the incoming request is already aborted", async () => {
+    let signalFired = false;
+    const fh = appFrom(() => async (request) => {
+      await new Promise<void>((resolve) => {
+        if (request.signal.aborted) {
+          signalFired = true;
+          return resolve();
+        }
+        request.signal.addEventListener("abort", () => {
+          signalFired = true;
+          resolve();
+        });
+        setTimeout(resolve, 1000);
+      });
+      return new Response("done");
+    });
+
+    const ctrl = new AbortController();
+    ctrl.abort(); // aborted before connectToWeb is even called
+    const body = new ReadableStream({ pull() {} });
+    await fh(streamingRequest("http://localhost/t", { method: "POST", body, signal: ctrl.signal })).catch(
+      () => undefined,
+    );
+    await new Promise((r) => setTimeout(r, 100));
+    expect(signalFired).toBe(true);
+  });
+
+  it("fires the handler's signal when aborted mid-stream (after the response is readable)", async () => {
+    let signalFired = false;
+    const fh = appFrom(() => async (request) => {
+      request.signal.addEventListener("abort", () => {
+        signalFired = true;
+      });
+      const enc = new TextEncoder();
+      let i = 0;
+      const stream = new ReadableStream<Uint8Array>({
+        async pull(c) {
+          if (i >= 20) return c.close();
+          c.enqueue(enc.encode(`chunk${i++};`));
+          await new Promise((r) => setTimeout(r, 40));
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/plain" } });
+    });
+
+    const ctrl = new AbortController();
+    const res = defined(
+      await fh(
+        streamingRequest("http://localhost/t", {
+          method: "POST",
+          body: new ReadableStream({ pull() {} }),
+          signal: ctrl.signal,
+        }),
+      ),
+    );
+    const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+    await reader.read(); // first chunk -> response is now readable (abort listener must stay alive)
+    ctrl.abort();
+    await new Promise((r) => setTimeout(r, 150));
+    expect(signalFired).toBe(true);
+  });
 });
 
 describe("connectToWeb — real-Node path uses the provided req/res", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request cancellation handling in the Express adapter, ensuring abort signals propagate correctly to handlers.
  * Enhanced Express framework compatibility by providing proper request metadata and socket properties.

* **Tests**
  * Expanded test coverage for the Express adapter, validating request handling, streaming, redirects, and response behavior across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->