### PR TITLE
fix(sirv): send the requested byte range instead of the whole file

### DIFF
--- a/.changeset/tricky-moons-shake.md
+++ b/.changeset/tricky-moons-shake.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/sirv": patch
+---
+
+fix(sirv): send the requested byte range instead of the whole file

--- a/packages/sirv/src/middleware.ts
+++ b/packages/sirv/src/middleware.ts
@@ -94,45 +94,59 @@ function viaLocal(dir: string, isEtag: boolean, uri: string, extns: string[]): F
   return undefined;
 }
 
-function send(req: Request, file: string, stats: fs.Stats, headers: Record<string, string>): Response | undefined {
-  let code = 200;
-  const opts: { start?: number; end?: number } = {};
+function send(req: Request, file: string, stats: fs.Stats, headers: Record<string, string>): Response {
   const newHeaders = { ...headers };
+  // A range addresses the bytes actually sent, and a partial gzip/brotli stream
+  // is not decodable, so a precompressed variant is always served whole.
+  const supportsRanges = !headers["Content-Encoding"];
+  const rangeHeader = supportsRanges && req.headers.get("range");
+  const range = rangeHeader ? parseRange(rangeHeader, stats.size) : undefined;
 
-  const rangeHeader = req.headers.get("range");
-
-  if (rangeHeader) {
-    code = 206;
-    const [x, y] = rangeHeader.replace("bytes=", "").split("-");
-    // biome-ignore lint/suspicious/noAssignInExpressions: ignored
-    let end = (opts.end = Number.parseInt(y, 10) || stats.size - 1);
-    // biome-ignore lint/suspicious/noAssignInExpressions: ignored
-    const start = (opts.start = Number.parseInt(x, 10) || 0);
-
-    if (end >= stats.size) {
-      end = stats.size - 1;
-    }
-
-    if (start >= stats.size) {
-      return new Response(null, {
-        status: 416,
-        headers: {
-          "Content-Range": `bytes */${stats.size}`,
-        },
-      });
-    }
-
-    newHeaders["Content-Range"] = `bytes ${start}-${end}/${stats.size}`;
-    newHeaders["Content-Length"] = (end - start + 1).toString();
-    newHeaders["Accept-Ranges"] = "bytes";
+  if (range === "unsatisfiable") {
+    return new Response(null, {
+      status: 416,
+      headers: { "Content-Range": `bytes */${stats.size}` },
+    });
   }
 
-  const webStream = Readable.toWeb(fs.createReadStream(file)) as unknown as ReadableStream<Uint8Array>;
+  if (supportsRanges) newHeaders["Accept-Ranges"] = "bytes";
+
+  if (range) {
+    newHeaders["Content-Range"] = `bytes ${range.start}-${range.end}/${stats.size}`;
+    newHeaders["Content-Length"] = (range.end - range.start + 1).toString();
+  }
+
+  const webStream = Readable.toWeb(fs.createReadStream(file, range)) as unknown as ReadableStream<Uint8Array>;
 
   return new Response(webStream, {
-    status: code,
+    status: range ? 206 : 200,
     headers: newHeaders,
   });
+}
+
+// The trailing "-" is optional so that "bytes=2" keeps working as "bytes=2-".
+const RANGE_REGEX = /^bytes=(\d*)-?(\d*)$/;
+
+/** Resolves a `bytes=` range against a size; `undefined` when the header must be ignored (RFC 9110 §14.2). */
+function parseRange(header: string, size: number): { start: number; end: number } | "unsatisfiable" | undefined {
+  const match = RANGE_REGEX.exec(header.trim());
+  if (!match) return undefined;
+
+  const [, rawStart, rawEnd] = match;
+  if (rawStart === "" && rawEnd === "") return undefined;
+
+  let start: number;
+  let end: number;
+  if (rawStart === "") {
+    // "bytes=-500" asks for the last 500 bytes, not for bytes 0 through 500.
+    start = Math.max(size - Number.parseInt(rawEnd, 10), 0);
+    end = size - 1;
+  } else {
+    start = Number.parseInt(rawStart, 10);
+    end = rawEnd === "" ? size - 1 : Math.min(Number.parseInt(rawEnd, 10), size - 1);
+  }
+
+  return start > end ? "unsatisfiable" : { start, end };
 }
 
 const ENCODING: Record<string, string> = {
@@ -203,7 +217,7 @@ function createUniversalMiddleware(
       data.headers["Vary"] = "Accept-Encoding";
     }
 
-    const response = send(request, data.abs, data.stats, data.headers) as Response;
+    const response = send(request, data.abs, data.stats, data.headers);
     setHeaders(response, pathname, data.stats);
     return response;
   };

--- a/packages/sirv/tests/helpers.ts
+++ b/packages/sirv/tests/helpers.ts
@@ -1,5 +1,5 @@
 import { readFile, stat, unlink, writeFile } from "node:fs/promises";
-import { createServer, type Server } from "node:http";
+import { createServer, type IncomingHttpHeaders, request, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -39,6 +39,41 @@ export function listen(server: Server) {
   server.listen(); // boots
   const { port } = server.address() as AddressInfo;
   return `http://localhost:${port}`;
+}
+
+/**
+ * Issues a request with `node:http` and returns the raw response bytes.
+ *
+ * `fetch` validates the response against its own framing rules and rejects when
+ * the body does not match `Content-Length`, which hides the very mismatch some
+ * tests need to observe. This helper reports whatever reached the client.
+ */
+export function sendRaw(
+  address: URL,
+  method: string,
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; headers: IncomingHttpHeaders; body: Buffer; error?: Error }> {
+  return new Promise((resolve, reject) => {
+    const req = request({ hostname: address.hostname, port: Number(address.port), path, method, headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      const settle = (error?: Error) =>
+        resolve({
+          status: res.statusCode as number,
+          headers: res.headers,
+          body: Buffer.concat(chunks),
+          error,
+        });
+      res.on("end", () => settle());
+      // A truncated/aborted response still carries the evidence we assert on.
+      res.on("error", settle);
+      res.on("aborted", () => settle(new Error("response aborted")));
+    });
+
+    req.on("error", reject);
+    req.end();
+  });
 }
 
 const CACHE: Record<

--- a/packages/sirv/tests/ranges.spec.ts
+++ b/packages/sirv/tests/ranges.spec.ts
@@ -1,0 +1,191 @@
+import { assert, describe, test } from "vitest";
+import * as utils from "./helpers";
+
+// The pre-existing "ranges" block in sirv.spec.ts asserts response headers only,
+// so the body the client actually receives is unverified — as are the parsing
+// edge cases below. Ported from srvx#275.
+
+const FILE = "/bundle.67329.js";
+
+describe("ranges :: body", () => {
+  test("should send only the requested bytes, not the whole file", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=0-10" });
+
+      assert.equal(res.status, 206);
+      assert.equal(res.headers["content-length"], "11");
+      assert.equal(res.headers["content-range"], `bytes 0-10/${file.size}`);
+      // The body must match the advertised Content-Range/Content-Length.
+      assert.equal(res.body.length, 11, "body length must match Content-Length");
+      assert.equal(res.body.toString("utf8"), file.data.slice(0, 11));
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should send only the requested bytes :: middle", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=6-96" });
+
+      assert.equal(res.status, 206);
+      assert.equal(res.body.length, 91, "body length must match Content-Length");
+      assert.equal(res.body.toString("utf8"), file.data.slice(6, 97));
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should send only the requested bytes :: dev", async () => {
+    const server = utils.http({ dev: true });
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=0-10" });
+
+      assert.equal(res.status, 206);
+      assert.equal(res.body.length, 11, "body length must match Content-Length");
+      assert.equal(res.body.toString("utf8"), file.data.slice(0, 11));
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("ranges :: parsing", () => {
+  test("should treat a suffix range as the *last* N bytes", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      // RFC 9110 §14.1.2: "bytes=-10" requests the final 10 bytes.
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=-10" });
+
+      assert.equal(res.status, 206);
+      assert.equal(res.headers["content-range"], `bytes ${file.size - 10}-${file.size - 1}/${file.size}`);
+      assert.equal(res.headers["content-length"], "10");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should serve a single byte for `bytes=0-0`", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=0-0" });
+
+      assert.equal(res.status, 206);
+      assert.equal(res.headers["content-range"], `bytes 0-0/${file.size}`);
+      assert.equal(res.headers["content-length"], "1");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should answer 416 for an unsatisfiable `bytes=-0` suffix range", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      // A zero-length suffix range is unsatisfiable.
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=-0" });
+
+      assert.equal(res.status, 416);
+      assert.equal(res.headers["content-range"], `bytes */${file.size}`);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should ignore a malformed Range header and serve the full file", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      // RFC 9110 §14.2: an unsatisfiable-to-parse Range is ignored.
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=abc-def" });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers["content-length"], String(file.size));
+      assert.equal(res.headers["content-range"], undefined);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should ignore a multi-range request and serve the full file", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      // multipart/byteranges is not implemented, so the Range must be ignored
+      // rather than silently answered with only its first range.
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=0-1,5-6" });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers["content-length"], String(file.size));
+      assert.equal(res.headers["content-range"], undefined);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should ignore a Range header whose unit is not `bytes`", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "items=0-10" });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers["content-length"], String(file.size));
+      assert.equal(res.headers["content-range"], undefined);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("ranges :: advertising", () => {
+  test('should advertise "Accept-Ranges: bytes" on a normal 200 response', async () => {
+    const server = utils.http();
+
+    try {
+      const res = await utils.sendRaw(server.address, "GET", FILE);
+
+      assert.equal(res.status, 200);
+      // Without this a client never knows it may issue a Range request.
+      assert.equal(res.headers["accept-ranges"], "bytes");
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("ranges :: precompressed variants", () => {
+  test("should ignore a Range request for an encoded variant", async () => {
+    const server = utils.http({ gzip: true });
+
+    try {
+      // A byte range over a `.gz` would hand the client a partial gzip stream.
+      const res = await utils.sendRaw(server.address, "GET", "/data.js", {
+        "Accept-Encoding": "gzip",
+        Range: "bytes=0-4",
+      });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers["content-encoding"], "gzip");
+      assert.equal(res.headers["content-range"], undefined);
+      assert.equal(res.headers["accept-ranges"], undefined);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/packages/sirv/tests/sirv.spec.ts
+++ b/packages/sirv/tests/sirv.spec.ts
@@ -1064,7 +1064,9 @@ describe("ranges", () => {
       assert.equal(res2.status, 200);
       assert.equal(res2.headers.get("content-length"), `${file.size}`);
       assert.notOk(res2.headers.get("content-range"));
-      assert.notOk(res2.headers.get("accept-ranges"));
+      // `Accept-Ranges` is now advertised on every identity response, so it is
+      // no longer a marker of leaked per-request headers.
+      assert.equal(res2.headers.get("accept-ranges"), "bytes");
     } finally {
       server.close();
     }
@@ -1085,7 +1087,9 @@ describe("ranges", () => {
       assert.equal(res2.status, 200);
       assert.equal(res2.headers.get("content-length"), `${file.size}`);
       assert.notOk(res2.headers.get("content-range"));
-      assert.notOk(res2.headers.get("accept-ranges"));
+      // `Accept-Ranges` is now advertised on every identity response, so it is
+      // no longer a marker of leaked per-request headers.
+      assert.equal(res2.headers.get("accept-ranges"), "bytes");
     } finally {
       server.close();
     }


### PR DESCRIPTION
## Problem

`send()` computed the range offsets into an `opts` object and then never passed it to `createReadStream`. Every `Range` request therefore answered with a partial `Content-Length` and `Content-Range` while writing the **entire file** to the socket.

Captured off the wire for `Range: bytes=0-10` against a 124-byte file:

```
HTTP/1.1 206 Partial Content
accept-ranges: bytes
content-length: 11
content-range: bytes 0-10/124
content-type: text/javascript
...

fetch("/2018-01-31-hello-world.md")
  .then((r) => r.text())
  .then(console.log);
//# sourceMappingURL=bundle.67329.js.map
```

All 124 bytes are on the wire under `content-length: 11`. Node does not reject the mismatch, so the surplus 113 bytes stay in the connection buffer and the **next** response on a keep-alive connection is parsed out of them — Node's own client answers `Parse Error: Expected HTTP/, RTSP/ or ICE/`. This affects any client that sends `Range`: media seeking, PDF viewers, download resumption.

The parsing was independently broken, because `parseInt(...) || fallback` treats a valid `0` as absent and `split("-")` cannot express the grammar:

| Request | Before | Expected |
|---|---|---|
| `bytes=-10` (last 10 bytes) | `bytes 0-10/124` | `bytes 114-123/124` |
| `bytes=0-0` (first byte) | `bytes 0-123/124` — whole file | `bytes 0-0/124` |
| `bytes=-0` | 206, whole file | 416 |
| `bytes=abc-def` | 206, whole file | 200, ignored |
| `bytes=0-1,5-6` | 206 of the first range only | 200, ignored |
| `items=0-10` | 206 | 200, ignored |

## Fix

Range parsing moves into `parseRange()`, built on a single regex, with a three-way result: a range, `null` for "valid but unsatisfiable" (416), or `undefined` for "must be ignored" (RFC 9110 §14.2 — a unit other than `bytes`, a syntax error, or a multi-range request we do not answer). The resolved offsets are then actually passed to `createReadStream`.

Two behaviour additions:

- **`Accept-Ranges: bytes` is now advertised on identity responses.** Previously it was only set on a 206, so a client had no way to learn ranges were supported. This changes two existing assertions in `sirv.spec.ts`, which used the *absence* of `Accept-Ranges` on a plain 200 as a proxy for "no per-request header leaked"; they now assert the header is present while still asserting `Content-Range` does not leak.
- **A `Range` over a precompressed variant is ignored.** Slicing a `.gz`/`.br` would hand the client a partial gzip/brotli stream it cannot decode, so those responses are served whole and omit `Accept-Ranges`.

The lenient `bytes=2` spelling (no trailing `-`) that the existing suite pins keeps working.

## Tests

`packages/sirv/tests/ranges.spec.ts` — 11 tests: body-matches-`Content-Length` for start/middle ranges in both `dev` and production modes, each parsing case in the table above, `Accept-Ranges` on a 200, and the precompressed-variant rule.

The body assertions go through a new `sendRaw` helper (`node:http`) rather than `fetch`, because `fetch` rejects on exactly the `Content-Length` mismatch under test and would hide it.

`pnpm test` in `packages/sirv`: 87 passed. Typecheck and Biome clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Static file requests using valid byte ranges now return only the requested portion of the file.
  * Added proper partial response headers and status codes for range requests.
  * Unsatisfiable ranges now return a clear `416` response.
  * Invalid or unsupported ranges continue to receive the complete file.
  * Range requests are safely ignored for precompressed files.
  * Static file responses now advertise byte-range support consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->