### PR TITLE
fix(sirv): apply the dotfile policy in `dev` mode and contain symlinks

### DIFF
--- a/.changeset/quiet-donkeys-jam.md
+++ b/.changeset/quiet-donkeys-jam.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/sirv": patch
+---
+
+fix(sirv): apply the dotfile policy in `dev` mode and contain symlinks

--- a/packages/sirv/src/middleware.ts
+++ b/packages/sirv/src/middleware.ts
@@ -73,7 +73,14 @@ function viaCache(cache: Record<string, FileData>, uri: string, extns: string[])
   return undefined;
 }
 
-function viaLocal(dir: string, isEtag: boolean, uri: string, extns: string[]): FileData | undefined {
+function viaLocal(
+  dir: string,
+  realDir: string,
+  isEtag: boolean,
+  allowDotfiles: boolean,
+  uri: string,
+  extns: string[],
+): FileData | undefined {
   let i = 0;
   const arr = toAssume(uri, extns);
   let abs: string;
@@ -83,15 +90,33 @@ function viaLocal(dir: string, isEtag: boolean, uri: string, extns: string[]): F
   for (; i < arr.length; i++) {
     // biome-ignore lint/suspicious/noAssignInExpressions: ignored
     abs = normalize(join(dir, (name = arr[i])));
+    if (!allowDotfiles && hasHiddenSegment(name)) continue;
     if (abs.startsWith(dir) && fs.existsSync(abs)) {
       stats = fs.statSync(abs);
       if (stats.isDirectory()) continue;
+      if (!isContained(realDir, abs)) continue;
       headers = toHeaders(name, stats, isEtag);
       headers["Cache-Control"] = isEtag ? "no-cache" : "no-store";
       return { abs, stats, headers };
     }
   }
   return undefined;
+}
+
+/** `.well-known` is exempt — RFC 8615 reserves it for public metadata — but only that segment, not what nests under it. */
+function hasHiddenSegment(name: string): boolean {
+  return name
+    .split(/[\\/]+/)
+    .some((segment) => segment.startsWith(".") && segment !== "." && segment !== ".." && segment !== ".well-known");
+}
+
+/** `stat` follows symlinks, so a lexical prefix check cannot see a link pointing out of the served directory. */
+function isContained(realDir: string, abs: string): boolean {
+  try {
+    return fs.realpathSync(abs).startsWith(join(realDir, sep));
+  } catch {
+    return false;
+  }
 }
 
 function send(req: Request, file: string, stats: fs.Stats, headers: Record<string, string>): Response {
@@ -225,6 +250,8 @@ function createUniversalMiddleware(
 
 export default function serveStatic(dir?: string, opts: ServeOptions = {}): UniversalMiddleware {
   dir = resolve(dir || ".");
+  // Resolved too, so that a symlinked root does not reject every file under it.
+  const realDir = fs.realpathSync(dir);
 
   const isNotFound: OnNoMatch | undefined = opts.onNoMatch;
   const setHeaders: SetHeadersFunction = opts.setHeaders || noop;
@@ -238,6 +265,7 @@ export default function serveStatic(dir?: string, opts: ServeOptions = {}): Univ
   let fallback = "/";
   const isEtag = !!opts.etag;
   const isSPA = !!opts.single;
+  const allowDotfiles = !!opts.dotfiles;
   if (typeof opts.single === "string") {
     const idx = opts.single.lastIndexOf(".");
     fallback += ~idx ? opts.single.substring(0, idx) : opts.single;
@@ -246,7 +274,7 @@ export default function serveStatic(dir?: string, opts: ServeOptions = {}): Univ
   const ignores: RegExp[] = [];
   if (opts.ignores !== false) {
     ignores.push(/[/]([A-Za-z\s\d~$._-]+\.\w+){1,}$/); // any extn
-    if (opts.dotfiles) ignores.push(/\/\.\w/);
+    if (allowDotfiles) ignores.push(/\/\.\w/);
     else ignores.push(/\/\.well-known/);
     const optsIgnores = Array.isArray(opts.ignores) ? opts.ignores : opts.ignores ? [opts.ignores] : [];
     for (const x of optsIgnores) {
@@ -260,9 +288,9 @@ export default function serveStatic(dir?: string, opts: ServeOptions = {}): Univ
 
   if (!opts.dev) {
     totalist(dir, (name: string, abs: string, stats: fs.Stats) => {
-      if (/\.well-known[\\+/]/.test(name)) {
-      } // keep
-      else if (!opts.dotfiles && /(^\.|[\\+|/+]\.)/.test(name)) return;
+      if (!allowDotfiles && hasHiddenSegment(name)) return;
+      // The walk follows symlinks, so an entry can still resolve outside `dir`.
+      if (!isContained(realDir, abs)) return;
 
       const headers = toHeaders(name, stats, isEtag);
       if (cc) headers["Cache-Control"] = cc;
@@ -272,7 +300,7 @@ export default function serveStatic(dir?: string, opts: ServeOptions = {}): Univ
   }
 
   const lookupFn = opts.dev
-    ? (uri: string, extns: string[]) => viaLocal(dir + sep, isEtag, uri, extns)
+    ? (uri: string, extns: string[]) => viaLocal(dir + sep, realDir, isEtag, allowDotfiles, uri, extns)
     : (uri: string, extns: string[]) => viaCache(FILES, uri, extns);
 
   return createUniversalMiddleware(

--- a/packages/sirv/tests/security.spec.ts
+++ b/packages/sirv/tests/security.spec.ts
@@ -1,0 +1,92 @@
+import { symlinkSync, unlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { assert, describe, test } from "vitest";
+import * as utils from "./helpers";
+
+// The equivalent assertions in sirv.spec.ts are written as
+// `send(...).catch((err) => assert.equal(err.status, 404))`; `fetch` resolves for
+// any HTTP status, so that callback never runs and those tests pass whatever the
+// server does. These assert on the status directly. Ported from srvx#252.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const www = join(__dirname, "public");
+
+describe("dotfiles :: dev", () => {
+  test("should reject a bare dotfile", async () => {
+    const server = utils.http({ dev: true });
+
+    try {
+      const res = await server.send("GET", "/.hello");
+      assert.equal(res.status, 404);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should reject a dotfile with an extension", async () => {
+    const server = utils.http({ dev: true });
+
+    try {
+      const res = await server.send("GET", "/.hello.txt");
+      assert.equal(res.status, 404);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should reject a dotfile in a sub-directory", async () => {
+    const server = utils.http({ dev: true });
+
+    try {
+      const res = await server.send("GET", "/foo/.world");
+      assert.equal(res.status, 404);
+    } finally {
+      server.close();
+    }
+  });
+
+  test('should still serve ".well-known" contents', async () => {
+    const server = utils.http({ dev: true });
+
+    try {
+      const res = await server.send("GET", "/.well-known/example");
+      assert.equal(res.status, 200);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("symlinks", () => {
+  test("should not serve a symlink that escapes the served directory :: dev", async () => {
+    const link = join(www, "escape.txt");
+    // Anything outside `public/` will do; package.json is guaranteed present.
+    symlinkSync(join(__dirname, "..", "package.json"), link);
+    const server = utils.http({ dev: true });
+
+    try {
+      const res = await server.send("GET", "/escape.txt");
+      assert.equal(res.status, 404);
+    } finally {
+      server.close();
+      unlinkSync(link);
+    }
+  });
+
+  test("should not serve a symlink that escapes the served directory :: prod", async () => {
+    const link = join(www, "escape.txt");
+    symlinkSync(join(__dirname, "..", "package.json"), link);
+    // The startup scan runs in the `sirv()` call inside `utils.http`, so the
+    // link must exist before the server is created.
+    const server = utils.http({ dev: false });
+
+    try {
+      const res = await server.send("GET", "/escape.txt");
+      assert.equal(res.status, 404);
+    } finally {
+      server.close();
+      unlinkSync(link);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

**1. `dev: true` serves dotfiles.** The dotfile filter lives in the `totalist` startup scan, which only runs when `dev` is false. The `dev` lookup (`viaLocal`) reads the disk per request and applies no policy at all, so every dot path under the served directory is public:

| Request (`dev: true`) | Before | Expected |
|---|---|---|
| `/.hello` | **200** | 404 |
| `/.hello.txt` | **200** | 404 |
| `/foo/.world` | **200** | 404 |

In a real project those paths are `.env`, `.env.production` and `.git/config`.

**2. Symlinks escape the served directory, in both modes.** Containment was the lexical check `abs.startsWith(dir)`, but `stat` follows symlinks, so the check cannot see where the path actually lands. A symlink inside the served directory serves any file the process can read — confirmed in both `dev` and production.

**Why this went unnoticed:** the existing assertions for this in `sirv.spec.ts` are written as

```js
await server.send("GET", "/.hello").catch((err) => {
  assert.equal(err.status, 404);
});
```

`fetch` resolves for *any* HTTP status, so the callback never runs and the test passes regardless of what the server does. The same shape is used by the directory-traversal tests. The new tests assert directly on `res.status`.

## Fix

- `hasHiddenSegment()` — one dotfile predicate for both modes. It replaces the two regexes in the startup scan as well as filling the gap in `viaLocal`, so there is a single definition of "hidden" rather than one per lookup path. The RFC 8615 `/.well-known/` carve-out is preserved as a segment-level exemption. It runs inside the lookup, so `single`-mode SPA fallback behaviour is unchanged (a dotfile request still falls through to the fallback rather than hard-404ing).

  One production behaviour tightens as a result: the old scan exempted *everything* under `.well-known/` via a separate regex, so `/.well-known/.env` was served. The exemption now covers that one segment, not what nests beneath it.
- `isContained()` — re-asserts containment against the `realpath`-resolved path in both modes. Both sides are resolved so a legitimately symlinked root (`/var/www` → `/data/www`) keeps serving its own files, and the lexical `startsWith` stays as a cheap pre-filter. The resolution runs only for the file about to be served, so the cost is one `realpath` on the hit path and none on a miss; the root is resolved once at setup.

## Tests

`packages/sirv/tests/security.spec.ts` — 6 tests: the three `dev` dotfile cases, `.well-known` still served in `dev`, and escaping symlinks rejected in both modes (the fixture link is created and removed by the test).

`pnpm test` in `packages/sirv`: 82 passed. Typecheck and Biome clean.

