### PR TITLE
fix(node): resolve `X-Forwarded-*` from the trusted hop and gate it on `trustProxy`

### DIFF
--- a/.changeset/great-donuts-shave.md
+++ b/.changeset/great-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/node": patch
+---
+
+fix(node): resolve `X-Forwarded-*` from the trusted hop and gate it on `trustProxy`

--- a/packages/adapter-express/tests/node-forwarded.spec.ts
+++ b/packages/adapter-express/tests/node-forwarded.spec.ts
@@ -1,0 +1,123 @@
+import { EventEmitter } from "node:events";
+import { type IncomingMessage, ServerResponse } from "node:http";
+import { createRequestAdapter, responseAdapter } from "@universal-middleware/node";
+import { describe, expect, it } from "vitest";
+
+// `@universal-middleware/node` has no test setup of its own; it is exercised
+// here because adapter-express (and adapter-fastify) build directly on it.
+//
+// Ported from srvx#229 (hop-aware `X-Forwarded-*` resolution).
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal stand-ins for req/res
+type Any = any;
+
+function fakeReq(headers: Record<string, string>, url = "/p"): Any {
+  return { method: "GET", url, headers, socket: {} };
+}
+
+function fakeRes(): Any {
+  const res = new EventEmitter() as Any;
+  res.writableEnded = false;
+  return res;
+}
+
+describe("createRequestAdapter — X-Forwarded-* resolution", () => {
+  // Proxies *append* to the forwarded headers, so the leftmost value is the one
+  // the client sent and the rightmost is the one the trusted proxy contributed.
+  // Reading left-to-right lets a client dictate the origin of `request.url`.
+  it("resolves X-Forwarded-Host from the trusted hop, not the client-supplied value", () => {
+    const adapter = createRequestAdapter({ trustProxy: true });
+    const request = adapter(
+      fakeReq({
+        host: "real.example",
+        // "evil.test" was spoofed by the client; "real.example" was appended by
+        // the proxy we actually trust.
+        "x-forwarded-host": "evil.test, real.example",
+      }),
+      fakeRes(),
+    );
+
+    expect(new URL(request.url).host).toBe("real.example");
+  });
+
+  it("resolves X-Forwarded-Proto from the trusted hop, not the client-supplied value", () => {
+    const adapter = createRequestAdapter({ trustProxy: true });
+    const request = adapter(
+      fakeReq({
+        host: "real.example",
+        "x-forwarded-proto": "https, http",
+      }),
+      fakeRes(),
+    );
+
+    expect(new URL(request.url).protocol).toBe("http:");
+  });
+
+  it("still honors a single forwarded value from the proxy", () => {
+    const adapter = createRequestAdapter({ trustProxy: true });
+    const request = adapter(
+      fakeReq({ host: "internal:8080", "x-forwarded-host": "public.example", "x-forwarded-proto": "https" }),
+      fakeRes(),
+    );
+
+    expect(request.url).toBe("https://public.example/p");
+  });
+
+  it("ignores X-Forwarded-Host entirely when trustProxy is off", () => {
+    const adapter = createRequestAdapter({ trustProxy: false });
+    const request = adapter(fakeReq({ host: "real.example", "x-forwarded-host": "evil.test" }), fakeRes());
+
+    expect(new URL(request.url).host).toBe("real.example");
+  });
+});
+
+describe("responseAdapter — redirect Location must not be attacker-controlled", () => {
+  // `getFullUrl` absolutized a relative Location using X-Forwarded-Host with no
+  // `trustProxy` gate at all, turning a local redirect into an open redirect.
+  it("does not build the redirect origin from an untrusted X-Forwarded-Host", () => {
+    const incoming = {
+      headers: { host: "real.example", "x-forwarded-host": "evil.test" },
+      socket: {},
+    } as unknown as IncomingMessage;
+
+    const res = new ServerResponse(incoming);
+    res.statusCode = 302;
+    res.setHeader("location", "/next");
+
+    const response = responseAdapter(res);
+    const location = response.headers.get("location") as string;
+
+    expect(new URL(location).host).toBe("real.example");
+  });
+
+  it("does not build the redirect origin from an untrusted X-Forwarded-Proto", () => {
+    const incoming = {
+      headers: { host: "real.example", "x-forwarded-proto": "https" },
+      socket: {},
+    } as unknown as IncomingMessage;
+
+    const res = new ServerResponse(incoming);
+    res.statusCode = 302;
+    res.setHeader("location", "/next");
+
+    const response = responseAdapter(res);
+    const location = response.headers.get("location") as string;
+
+    expect(new URL(location).protocol).toBe("http:");
+  });
+
+  it("leaves an absolute Location untouched", () => {
+    const incoming = {
+      headers: { host: "real.example", "x-forwarded-host": "evil.test" },
+      socket: {},
+    } as unknown as IncomingMessage;
+
+    const res = new ServerResponse(incoming);
+    res.statusCode = 301;
+    res.setHeader("location", "https://elsewhere.example/there");
+
+    const response = responseAdapter(res);
+
+    expect(response.headers.get("location")).toBe("https://elsewhere.example/there");
+  });
+});

--- a/packages/node/src/forwarded.ts
+++ b/packages/node/src/forwarded.ts
@@ -1,0 +1,20 @@
+import type { IncomingHttpHeaders } from "node:http";
+import { env } from "./const.js";
+
+/** Whether `X-Forwarded-*` may be believed at all. */
+export function trustsProxy(): boolean {
+  return env.TRUST_PROXY === "1";
+}
+
+// TODO: Support the newer `Forwarded` standard header
+/**
+ * The `X-Forwarded-<name>` value contributed by the nearest proxy — the rightmost
+ * entry, since proxies append and the leftmost is whatever the client sent.
+ */
+export function forwardedValue(headers: IncomingHttpHeaders, name: string): string | undefined {
+  const value = headers[`x-forwarded-${name}`];
+  if (!value) return undefined;
+
+  const hops = String(value).split(",");
+  return hops[hops.length - 1].trim() || undefined;
+}

--- a/packages/node/src/request.ts
+++ b/packages/node/src/request.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Socket } from "node:net";
 import type { contextSymbol } from "@universal-middleware/core";
 import { env, requestSymbol } from "./const.js";
+import { forwardedValue, trustsProxy } from "./forwarded.js";
 
 export { env, requestSymbol };
 
@@ -47,8 +48,9 @@ export interface NodeRequestAdapterOptions {
    * Whether to trust `X-Forwarded-*` headers. `X-Forwarded-Proto`
    * and `X-Forwarded-Host` are used to determine the origin when
    * `origin` and `process.env.ORIGIN` are not set. `X-Forwarded-For`
-   * is used to determine the IP address. The leftmost values are used
-   * if multiple values are set. Defaults to true if `process.env.TRUST_PROXY`
+   * is used to determine the IP address. The rightmost value is used
+   * if multiple values are set, as that is the one contributed by the
+   * nearest proxy. Defaults to true if `process.env.TRUST_PROXY`
    * is set to `1`, otherwise false.
    */
   trustProxy?: boolean;
@@ -58,7 +60,7 @@ export interface NodeRequestAdapterOptions {
 export function createRequestAdapter(
   options: NodeRequestAdapterOptions = {},
 ): (req: DecoratedRequest, res: ServerResponse) => Request {
-  const { origin = env.ORIGIN, trustProxy = env.TRUST_PROXY === "1" } = options;
+  const { origin = env.ORIGIN, trustProxy = trustsProxy() } = options;
 
   // eslint-disable-next-line prefer-const
   let { protocol: protocolOverride, host: hostOverride } = origin ? new URL(origin) : ({} as Record<string, undefined>);
@@ -75,11 +77,6 @@ export function createRequestAdapter(
       return req[requestSymbol];
     }
 
-    // TODO: Support the newer `Forwarded` standard header
-    function parseForwardedHeader(name: string) {
-      return (headers[`x-forwarded-${name}`] || "").split(",", 1)[0].trim();
-    }
-
     let headers = req.headers as Record<string, string>;
     // Filter out pseudo-headers
     if (headers[":method"]) {
@@ -88,13 +85,13 @@ export function createRequestAdapter(
 
     const protocol =
       protocolOverride ||
-      (trustProxy && parseForwardedHeader("proto")) ||
+      (trustProxy && forwardedValue(headers, "proto")) ||
       req.protocol ||
       // biome-ignore lint/suspicious/noExplicitAny: encrypted can exist in some express versions
       ((req.socket as any)?.encrypted && "https") ||
       "http";
 
-    let host = hostOverride || (trustProxy && parseForwardedHeader("host")) || headers.host;
+    let host = hostOverride || (trustProxy && forwardedValue(headers, "host")) || headers.host;
 
     if (!host && !warned) {
       console.warn(

--- a/packages/node/src/response.ts
+++ b/packages/node/src/response.ts
@@ -2,6 +2,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Readable } from "node:stream";
 import type { ReadableStream as ReadableStreamNode } from "node:stream/web";
 import { nodeHeadersToWeb } from "@universal-middleware/core";
+import { forwardedValue, trustsProxy } from "./forwarded.js";
+import type { PossiblyEncryptedSocket } from "./request.js";
 
 /**
  * Send a fetch API Response into a Node.js HTTP response stream.
@@ -61,11 +63,15 @@ function getFullUrl(pathnameOrFull: string, req: IncomingMessage): string {
   try {
     return new URL(pathnameOrFull).href;
   } catch {
-    const protocol = (req.socket as any)?.encrypted || req.headers["x-forwarded-proto"] === "https" ? "https" : "http";
-    const host = req.headers["x-forwarded-host"] || req.headers.host || "localhost";
-    const baseUrl = `${protocol}://${host}`;
+    // Without the opt-in, any client could set the header and point the redirect
+    // at a host of its choosing.
+    const trustProxy = trustsProxy();
+    const protocol =
+      (trustProxy && forwardedValue(req.headers, "proto")) ||
+      ((req.socket as PossiblyEncryptedSocket | undefined)?.encrypted ? "https" : "http");
+    const host = (trustProxy && forwardedValue(req.headers, "host")) || req.headers.host || "localhost";
 
-    return new URL(pathnameOrFull, baseUrl).href;
+    return new URL(pathnameOrFull, `${protocol}://${host}`).href;
   }
 }
 


### PR DESCRIPTION
## Problem

**1. The client-controlled end of `X-Forwarded-*` was the one being read.** Proxies *append* to these headers, so the leftmost entry is whatever the client sent and the rightmost is what the nearest — trusted — proxy contributed. `parseForwardedHeader` took `split(",", 1)[0]`, the leftmost:

```
X-Forwarded-Host: evil.test, real.example   ->  request.url built on evil.test
X-Forwarded-Proto: https, http              ->  request.url built on https
```

Under `trustProxy`, a client picks the origin of `request.url` — which feeds cache keys, absolute links and anything derived from the request URL.

**2. `responseAdapter` trusted the same headers with no gate at all.** `getFullUrl` absolutizes a relative `Location` before handing it to `Response.redirect`, and it read `x-forwarded-host` / `x-forwarded-proto` unconditionally — `trustProxy` was never consulted. Any client could turn an application's own `302 /next` into a redirect to a host it chose:

```js
// headers: { host: "real.example", "x-forwarded-host": "evil.test" }
res.statusCode = 302;
res.setHeader("location", "/next");
responseAdapter(res).headers.get("location");
// before: "https://evil.test/next"
```

## Fix

Both readers now come from one place. `src/forwarded.ts` holds `forwardedValue()` (the rightmost entry) and `trustsProxy()` (the `TRUST_PROXY=1` contract), and the request and response adapters share them rather than each carrying their own copy of the rule.

- `createRequestAdapter` reads the **rightmost** entry.
- `getFullUrl` honors forwarded values only when `trustProxy` is opted into, using the same signal as `createRequestAdapter`. Without the opt-in it derives the origin from the connection (`socket.encrypted`) and the `Host` header, as `createRequestAdapter` does.
- The `trustProxy` option's JSDoc said "the leftmost values are used"; it now documents the rightmost rule.

A deployment that already sets `TRUST_PROXY=1` (or passes `trustProxy`) keeps HTTPS redirects behind a TLS-terminating proxy; one that does not, no longer lets a header decide.

## Tests

`packages/adapter-express/tests/node-forwarded.spec.ts` — 7 tests: spoofed-prefix host and proto resolve to the proxy's value, a single forwarded value still wins, `trustProxy: false` ignores the header entirely, the redirect origin is not attacker-controlled for host or proto, and an absolute `Location` is passed through untouched.

`@universal-middleware/node` has no test setup of its own, so the tests live in `adapter-express`, which depends on it directly. Adding vitest to the `node` package would be a reasonable follow-up.

Typecheck and Biome clean; `adapter-express` and `sirv` suites unaffected.