### PR TITLE
fix(node): answer HEAD without draining the response body

### DIFF
--- a/.changeset/eighty-days-teach.md
+++ b/.changeset/eighty-days-teach.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/node": patch
+---
+
+fix(node): answer HEAD without draining the response body

--- a/packages/adapter-express/tests/node-head.spec.ts
+++ b/packages/adapter-express/tests/node-head.spec.ts
@@ -1,0 +1,98 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { UniversalHandler } from "@universal-middleware/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHandler } from "../src/index.js";
+
+// `@universal-middleware/node` has no test setup of its own; `sendResponse` is
+// exercised here because adapter-express builds directly on it.
+//
+// Ported from srvx#243 (HEAD responses must not pump the body stream).
+
+describe("sendResponse — HEAD must not pump the body", () => {
+  const servers: ReturnType<typeof createServer>[] = [];
+
+  afterEach(() => {
+    for (const server of servers.splice(0)) server.close();
+  });
+
+  function serve(handler: UniversalHandler): number {
+    const server = createServer(createHandler(() => handler)());
+    servers.push(server);
+    server.listen();
+    return (server.address() as AddressInfo).port;
+  }
+
+  it("cancels a streaming body instead of reading it to completion", async () => {
+    let pulls = 0;
+    let cancelled = false;
+    // Lets the test release an otherwise endless body so it cannot outlive the run.
+    let stop = false;
+
+    const port = serve(
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            async pull(controller) {
+              if (stop) return controller.close();
+              pulls++;
+              controller.enqueue(new Uint8Array(16));
+              // A real SSE/streaming body never ends; the delay just keeps this
+              // from spinning while the test observes it.
+              await new Promise((resolve) => setTimeout(resolve, 5));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+    );
+
+    const ctrl = new AbortController();
+    try {
+      const res = await Promise.race([
+        fetch(`http://localhost:${port}/`, { method: "HEAD", signal: ctrl.signal }),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 1500)),
+      ]);
+
+      // A HEAD response carries no body, so it must complete as soon as the
+      // headers are known — it must not wait on (or drain) the body stream.
+      expect(res, "HEAD request never completed: the body stream is still being pumped").not.toBeNull();
+      expect((res as Response).status).toBe(200);
+      expect((res as Response).headers.get("content-type")).toBe("text/event-stream");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const seen = pulls;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(pulls, "body stream is still being read after the HEAD response").toBe(seen);
+      expect(cancelled, "body stream was never released").toBe(true);
+    } finally {
+      stop = true;
+      ctrl.abort();
+    }
+  });
+
+  it("reports the headers a GET would have sent", async () => {
+    const port = serve(
+      () => new Response("hello world", { headers: { "content-type": "text/plain", "x-custom": "kept" } }),
+    );
+
+    const res = await fetch(`http://localhost:${port}/`, { method: "HEAD" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/plain");
+    expect(res.headers.get("x-custom")).toBe("kept");
+    expect(await res.text()).toBe("");
+  });
+
+  it("still sends the body for a GET", async () => {
+    const port = serve(() => new Response("hello world", { headers: { "content-type": "text/plain" } }));
+
+    const res = await fetch(`http://localhost:${port}/`);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello world");
+  });
+});

--- a/packages/node/src/response.ts
+++ b/packages/node/src/response.ts
@@ -48,6 +48,15 @@ export async function sendResponse(fetchResponse: Response, nodeResponse: Server
 
   setResponseHeaders(fetchResponse, nodeResponse);
 
+  // Node discards a HEAD body at the wire, and an endless one (SSE, a proxied
+  // stream) would keep the response from ever finishing. The headers still
+  // describe what a GET would have sent.
+  if (nodeResponse.req.method === "HEAD") {
+    body?.destroy();
+    nodeResponse.end();
+    return;
+  }
+
   if (body) {
     const { pipeline } = await import("node:stream/promises");
     await pipeline(body, nodeResponse).catch(() => {});


### PR DESCRIPTION
## Problem

`sendResponse` piped the response body into the Node response regardless of the request method. Node discards a HEAD body at the wire, so for a file-backed response this was pure waste — a full disk read for zero bytes delivered.

For a body that does not end on its own it is worse than waste. The pipeline never completes, so the response is never finished and the client waits indefinitely:

```js
// handler returns an open-ended stream (SSE, a proxied upstream)
await fetch(url, { method: "HEAD" }); // never settles
```

A HEAD request should return as soon as the headers are known. Before this change it hung until the client gave up, while the server kept pumping the stream.

## Fix

When the request method is HEAD, apply the response headers, destroy the body, and end the response. The check sits after the existing body conversion, so it reuses it rather than adding a second path: destroying the converted `Readable` cancels the underlying web stream, releasing whatever backs it (a file descriptor, an upstream response) instead of leaving it for GC. The headers still describe what a GET would have sent; no `content-length: 0` is invented.

## Tests

`packages/adapter-express/tests/node-head.spec.ts` — 3 tests: an endless stream is cancelled and stops being read while the HEAD request completes; a HEAD reports the same headers a GET would with an empty body; a GET still receives its body.

The streaming test fails in ~1.5s with `HEAD request never completed: the body stream is still being pumped` rather than hanging to the suite timeout, and releases its stream on the way out so it cannot outlive the run.

`@universal-middleware/node` has no test setup of its own, so the tests live in `adapter-express`, which depends on it directly.

Typecheck and Biome clean; `adapter-express` and `sirv` suites unaffected (`sirv` issues a HEAD request of its own).
