### PR TITLE
fix(express): strip hop-by-hop headers in `connectToWeb`

### DIFF
--- a/.changeset/rich-cups-wonder.md
+++ b/.changeset/rich-cups-wonder.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/express": patch
+---
+
+fix(express): strip hop-by-hop headers in `connectToWeb`

--- a/packages/adapter-express/src/utils.ts
+++ b/packages/adapter-express/src/utils.ts
@@ -217,11 +217,31 @@ function toWebStream(readable: Readable): ReadableStream {
       (Readable.toWeb(readable) as any);
 }
 
+/** Connection-specific headers: they describe one transport hop, not the message (RFC 9110 §7.6.1). */
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
 function flattenHeaders(headers: OutgoingHttpHeaders): [string, string][] {
   const flatHeaders: [string, string][] = [];
+  // The captured body is never chunk-framed, so a copied `Transfer-Encoding` would
+  // misframe it when served for real. Names listed in `Connection` are hop-by-hop too.
+  const connectionTokens = String(headers.connection ?? "").split(",");
+  const dropped = new Set([...HOP_BY_HOP_HEADERS, ...connectionTokens.map((name) => name.trim().toLowerCase())]);
 
   for (const [key, value] of Object.entries(headers)) {
     if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (dropped.has(key.toLowerCase())) {
       continue;
     }
 

--- a/packages/adapter-express/tests/hop-by-hop.spec.ts
+++ b/packages/adapter-express/tests/hop-by-hop.spec.ts
@@ -1,0 +1,67 @@
+import express from "express";
+import { describe, expect, it } from "vitest";
+import { connectToWeb } from "../src/index.js";
+
+// `connectToWeb` rebuilds the web Response from the synthetic `ServerResponse`'s
+// header snapshot, which also carries hop-by-hop headers (RFC 9110 §7.6.1).
+// Those describe a single transport hop and must not cross the bridge: the
+// captured body is *not* chunk-framed, so a `Transfer-Encoding: chunked` that
+// rides along makes the re-served response unparseable.
+//
+// Ported from srvx#268 and srvx#270.
+
+function defined(res: Response | undefined): Response {
+  expect(res).toBeInstanceOf(Response);
+  return res as Response;
+}
+
+function bridge(handler: express.RequestHandler) {
+  const app = express();
+  app.use("/t", handler);
+  return () => Promise.resolve(connectToWeb(app)(new Request("http://localhost/t")));
+}
+
+describe("connectToWeb — hop-by-hop headers must not leak", () => {
+  it("strips an explicitly set Transfer-Encoding, keeping the body verbatim", async () => {
+    const fh = bridge((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain", "transfer-encoding": "chunked" });
+      res.write("hello");
+      res.end("world");
+    });
+
+    const res = defined(await fh());
+    expect(await res.text()).toBe("helloworld");
+    expect(res.headers.get("transfer-encoding")).toBeNull();
+  });
+
+  it.each(["connection", "keep-alive", "upgrade", "te", "trailer", "proxy-authenticate"])(
+    "strips the %s header",
+    async (header) => {
+      const fh = bridge((_req, res) => {
+        res.setHeader("content-type", "text/plain");
+        res.setHeader(header, "keep-alive");
+        res.end("ok");
+      });
+
+      const res = defined(await fh());
+      expect(await res.text()).toBe("ok");
+      expect(res.headers.get(header)).toBeNull();
+      // End-to-end headers must survive the filtering.
+      expect(res.headers.get("content-type")).toBe("text/plain");
+    },
+  );
+
+  it("strips headers named in the Connection header", async () => {
+    const fh = bridge((_req, res) => {
+      res.setHeader("connection", "close, x-internal");
+      res.setHeader("x-internal", "secret");
+      res.setHeader("x-public", "fine");
+      res.end("ok");
+    });
+
+    const res = defined(await fh());
+    expect(res.headers.get("connection")).toBeNull();
+    expect(res.headers.get("x-internal")).toBeNull();
+    expect(res.headers.get("x-public")).toBe("fine");
+  });
+});


### PR DESCRIPTION
## Problem

`connectToWeb` rebuilds the web `Response` from the synthetic `ServerResponse`'s header snapshot and copied every header it found — including connection-specific ones (RFC 9110 §7.6.1), which describe a single transport hop and must not cross the bridge.

`Transfer-Encoding` is the damaging one. The bridge captures the handler's writes directly through a `PassThrough`, so the captured body is never chunk-framed. A handler that sets the header explicitly:

```js
app.use("/t", (req, res) => {
  res.writeHead(200, { "content-type": "text/plain", "transfer-encoding": "chunked" });
  res.write("hello");
  res.end("world");
});
```

produced a `Response` whose body is the plain `"helloworld"` but whose headers promise chunked framing. Serving that response for real hands the client a body that does not match its own framing.

`Connection`, `Keep-Alive`, `Upgrade`, `TE`, `Trailer` and the proxy-auth pair were passed through the same way, as were any field names *listed* in `Connection` — `Connection: close, x-internal` leaked `x-internal`.

## Fix

`flattenHeaders` now drops the hop-by-hop set, plus any field name named in the `Connection` header. End-to-end headers and the body are untouched.

## Tests

`packages/adapter-express/tests/hop-by-hop.spec.ts` — 8 tests: `Transfer-Encoding` stripped with the body arriving verbatim, each hop-by-hop header stripped while `Content-Type` survives, and the `Connection`-listed-token case.

`pnpm test` in `packages/adapter-express`: 76 passed. Typecheck and Biome clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented hop-by-hop HTTP headers from being exposed in responses handled through the Express adapter.
  * Correctly filters standard connection-specific headers and headers listed in the `Connection` header.
  * Preserves response bodies and end-to-end headers such as `Content-Type`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->