### PR TITLE
fix(compress): honor `q=0` in `Accept-Encoding` as a refusal

### DIFF
--- a/.changeset/proud-poems-smile.md
+++ b/.changeset/proud-poems-smile.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/compress": patch
+---
+
+fix(compress): honor `q=0` in `Accept-Encoding` as a refusal

--- a/packages/compress/src/encoding-header.ts
+++ b/packages/compress/src/encoding-header.ts
@@ -74,7 +74,8 @@ export function chooseBestEncoding(request: Request, availableEncodings: readonl
   for (const enc of availableEncodings) {
     const encodingEntry = parsed.get(enc);
 
-    if (encodingEntry) {
+    // RFC 9110 §12.5.3: a qvalue of 0 means "not acceptable".
+    if (encodingEntry && encodingEntry.q > 0) {
       // If no best encoding found or current encoding has higher q-value or better index
       if (
         !bestEncoding ||

--- a/packages/compress/test/accept-encoding.spec.ts
+++ b/packages/compress/test/accept-encoding.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { EncodingGuesser } from "../src/compress";
+import { chooseBestEncoding } from "../src/encoding-header";
+
+// `chooseBestEncoding` parses the quality values but never filters on them, so
+// an encoding the client explicitly refused can still win the negotiation.
+// RFC 9110 §12.5.3: "a qvalue of 0 means 'not acceptable'".
+//
+// Ported from the negotiation fixes in srvx#252.
+
+function req(acceptEncoding: string): Request {
+  return new Request("http://localhost", { headers: { "Accept-Encoding": acceptEncoding } });
+}
+
+describe("chooseBestEncoding :: q=0 is a refusal", () => {
+  it("should not pick an encoding that was refused outright", () => {
+    expect(chooseBestEncoding(req("gzip;q=0"), ["gzip", "deflate"])).not.toBe("gzip");
+  });
+
+  it("should not pick brotli when brotli was refused", () => {
+    expect(chooseBestEncoding(req("br;q=0"), ["br", "gzip"])).not.toBe("br");
+  });
+
+  it("should pick the acceptable encoding when another is refused", () => {
+    expect(chooseBestEncoding(req("br;q=0, gzip"), ["br", "gzip"])).toBe("gzip");
+  });
+
+  it("should treat `identity;q=0, gzip;q=0` as no acceptable encoding", () => {
+    const chosen = chooseBestEncoding(req("identity;q=0, gzip;q=0"), ["gzip", "deflate"]);
+    expect(chosen === undefined || chosen === null || chosen === "identity").toBe(true);
+  });
+});
+
+describe("EncodingGuesser :: q=0 is a refusal", () => {
+  it("should not compress when the only offered encoding was refused", () => {
+    expect(new EncodingGuesser(req("gzip;q=0")).encoding).toBeNull();
+  });
+
+  it("should still compress with an encoding that was not refused", () => {
+    expect(new EncodingGuesser(req("br;q=0, gzip")).encoding).toBe("gzip");
+  });
+});


### PR DESCRIPTION
## Problem

`chooseBestEncoding` parses quality values into its candidate map but never filters on them, so the only comparison is "higher q wins". When every available encoding is refused, the refused one is still the best candidate and gets returned:

```js
chooseBestEncoding(req("gzip;q=0"), ["gzip", "deflate"]); // "gzip"
new EncodingGuesser(req("gzip;q=0")).encoding;            // "gzip"
```

RFC 9110 §12.5.3: a qvalue of 0 means *not acceptable*. A client sends it when it cannot decode that coding, so compressing with it makes the response unusable.

## Fix

Skip candidates with `q === 0`. One condition, plus the rationale in a comment.

A request that refuses every available encoding now negotiates to nothing and `EncodingGuesser.encoding` is `null`, so the response is sent uncompressed.

## Tests

`packages/compress/test/accept-encoding.spec.ts` — 6 tests against both `chooseBestEncoding` and `EncodingGuesser`: refused gzip and brotli are not selected, `identity;q=0, gzip;q=0` yields no encoding, and the two cases that already worked (`br;q=0, gzip` picks gzip) are pinned so the fix cannot over-correct.

`pnpm test` in `packages/compress`: 52 passed. Typecheck and Biome clean.
