### PR TITLE
fix(sirv): honor `q=0` in `Accept-Encoding` as a refusal

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/sirv": patch
+---
+
+fix(sirv): honor `q=0` in `Accept-Encoding` as a refusal

--- a/packages/sirv/src/middleware.ts
+++ b/packages/sirv/src/middleware.ts
@@ -217,8 +217,9 @@ function createUniversalMiddleware(
     let pathname = url.pathname;
     const acceptEncoding = request.headers.get("accept-encoding") || "";
 
-    if (gzips && acceptEncoding.includes("gzip")) extns.unshift(...gzips);
-    if (brots && /(br|brotli)/i.test(acceptEncoding)) extns.unshift(...brots);
+    // Brotli is unshifted last so that it stays preferred when both are offered.
+    if (gzips && acceptsEncoding(acceptEncoding, ["gzip", "x-gzip"])) extns.unshift(...gzips);
+    if (brots && acceptsEncoding(acceptEncoding, ["br", "brotli"])) extns.unshift(...brots);
     extns.push(...extensions);
 
     if (pathname.indexOf("%") !== -1) {
@@ -246,6 +247,21 @@ function createUniversalMiddleware(
     setHeaders(response, pathname, data.stats);
     return response;
   };
+}
+
+/** Whether the client accepts one of `codings`. RFC 9110 §12.5.3: a qvalue of 0 means "not acceptable". */
+function acceptsEncoding(header: string, codings: string[]): boolean {
+  for (const entry of header.toLowerCase().split(",")) {
+    const [coding, ...params] = entry.split(";");
+    if (!codings.includes(coding.trim())) continue;
+
+    for (const param of params) {
+      const [key, value] = param.split("=");
+      if (key.trim() === "q") return Number.parseFloat(value) > 0;
+    }
+    return true;
+  }
+  return false;
 }
 
 export default function serveStatic(dir?: string, opts: ServeOptions = {}): UniversalMiddleware {

--- a/packages/sirv/tests/encoding.spec.ts
+++ b/packages/sirv/tests/encoding.spec.ts
@@ -1,0 +1,65 @@
+import { assert, describe, test } from "vitest";
+import * as utils from "./helpers";
+
+// Precompressed-variant negotiation (src/middleware.ts) matches the
+// `Accept-Encoding` header with `String.includes` / a loose RegExp, so it never
+// sees the quality values. RFC 9110 §12.5.3: "q=0" means *not acceptable*.
+//
+// Ported from the negotiation fixes in srvx#252.
+
+describe("accept-encoding :: q=0 is a refusal", () => {
+  test("should not serve a `.gz` variant when gzip is refused", async () => {
+    const server = utils.http({ gzip: true });
+
+    try {
+      const res = await server.send("GET", "/", { headers: { "Accept-Encoding": "gzip;q=0" } });
+
+      assert.equal(res.status, 200);
+      assert.notOk(res.headers.get("content-encoding"), "must not encode with a refused encoding");
+      await utils.matches(res, 200, "index.html", "utf8");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should not serve a `.br` variant when brotli is refused", async () => {
+    const server = utils.http({ brotli: true });
+
+    try {
+      const res = await server.send("GET", "/", { headers: { "Accept-Encoding": "br;q=0" } });
+
+      assert.equal(res.status, 200);
+      assert.notOk(res.headers.get("content-encoding"), "must not encode with a refused encoding");
+      await utils.matches(res, 200, "index.html", "utf8");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should fall back to gzip when only brotli is refused", async () => {
+    const server = utils.http({ gzip: true, brotli: true });
+
+    try {
+      const res = await server.send("GET", "/", { headers: { "Accept-Encoding": "br;q=0, gzip" } });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get("content-encoding"), "gzip");
+      assert.equal(await res.text(), "gzip html\n");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should 404 when the only representation is a refused encoding", async () => {
+    // `data.js` exists on disk *only* as `data.js.gz` / `data.js.br`.
+    const server = utils.http({ gzip: true });
+
+    try {
+      const res = await server.send("GET", "/data.js", { headers: { "Accept-Encoding": "gzip;q=0" } });
+
+      assert.equal(res.status, 404);
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Precompressed-variant selection matched the raw header with `String.includes` and a loose RegExp:

```js
if (gzips && acceptEncoding.includes("gzip")) extns.unshift(...gzips);
if (brots && /(br|brotli)/i.test(acceptEncoding)) extns.unshift(...brots);
```

Neither can see quality values, and RFC 9110 §12.5.3 gives `q=0` the meaning *not acceptable*. A client refusing an encoding was served it anyway:

| `Accept-Encoding` | Options | Before | Expected |
|---|---|---|---|
| `gzip;q=0` | `{ gzip: true }` | serves `.gz` | serves identity |
| `br;q=0` | `{ brotli: true }` | serves `.br` | serves identity |
| `br;q=0, gzip` | both | serves `.br` | serves `.gz` |
| `gzip;q=0` on a `.gz`-only file | `{ gzip: true }` | 200 gzip | 404 |

A client sends `q=0` when it genuinely cannot decode the encoding, so the response is unusable to it.

## Fix

`acceptsEncoding()` parses the header into codings and qvalues and answers whether a coding is acceptable. Brotli keeps its preference over gzip when both are acceptable, and the legacy `x-gzip` / `brotli` spellings are still recognised.

Scope note: this is accept/reject only. The client's relative *ranking* between two acceptable encodings is still not honored — server preference wins, which is what srvx settled on too. Only `q=0` is treated as binding. `Accept-Encoding: *` is likewise not expanded to concrete codings; it never was, and doing so would be new behaviour with no bug behind it.

## Tests

`packages/sirv/tests/encoding.spec.ts` — 4 tests, one per row of the table above.

`pnpm test` in `packages/sirv`: 80 passed. Typecheck and Biome clean.