### PR TITLE
test(sirv): give the symlink fixture its own directory

### DIFF
--- a/packages/sirv/tests/helpers.ts
+++ b/packages/sirv/tests/helpers.ts
@@ -13,10 +13,10 @@ const __dirname = dirname(__filename);
 
 const www = join(__dirname, "public");
 
-export const setup = (opts: ServeOptions = {}) => sirv(www, opts);
+export const setup = (opts: ServeOptions = {}, dir: string = www) => sirv(dir, opts);
 
-export function http(opts: ServeOptions = {}) {
-  const server = createServer(createMiddleware(() => setup(opts))());
+export function http(opts: ServeOptions = {}, dir: string = www) {
+  const server = createServer(createMiddleware(() => setup(opts, dir))());
   const address = new URL(listen(server));
   return {
     close: server.close.bind(server),

--- a/packages/sirv/tests/security.spec.ts
+++ b/packages/sirv/tests/security.spec.ts
@@ -1,4 +1,5 @@
-import { symlinkSync, unlinkSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { assert, describe, test } from "vitest";
@@ -10,7 +11,6 @@ import * as utils from "./helpers";
 // server does. These assert on the status directly. Ported from srvx#252.
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const www = join(__dirname, "public");
 
 describe("dotfiles :: dev", () => {
   test("should reject a bare dotfile", async () => {
@@ -58,35 +58,47 @@ describe("dotfiles :: dev", () => {
   });
 });
 
-describe("symlinks", () => {
-  test("should not serve a symlink that escapes the served directory :: dev", async () => {
-    const link = join(www, "escape.txt");
-    // Anything outside `public/` will do; package.json is guaranteed present.
-    symlinkSync(join(__dirname, "..", "package.json"), link);
-    const server = utils.http({ dev: true });
+/**
+ * A directory of its own, holding one regular file and one link out of it.
+ *
+ * The fixture cannot live in `public/`: spec files run in parallel, and creating
+ * or removing an entry there races the `totalist` scan that every production-mode
+ * server in the other suites performs over the same directory.
+ */
+function dirWithEscapingLink(): string {
+  const dir = mkdtempSync(join(tmpdir(), "sirv-symlink-"));
+  writeFileSync(join(dir, "inside.txt"), "inside\n");
+  // Anything outside the served directory will do; package.json is always present.
+  symlinkSync(join(__dirname, "..", "package.json"), join(dir, "escape.txt"));
+  return dir;
+}
+
+describe.each([{ dev: true }, { dev: false }])("symlinks :: dev: $dev", (opts) => {
+  test("should not serve a symlink that escapes the served directory", async () => {
+    const dir = dirWithEscapingLink();
+    // The production scan runs inside `sirv()`, so the link must already exist.
+    const server = utils.http(opts, dir);
 
     try {
       const res = await server.send("GET", "/escape.txt");
       assert.equal(res.status, 404);
     } finally {
       server.close();
-      unlinkSync(link);
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test("should not serve a symlink that escapes the served directory :: prod", async () => {
-    const link = join(www, "escape.txt");
-    symlinkSync(join(__dirname, "..", "package.json"), link);
-    // The startup scan runs in the `sirv()` call inside `utils.http`, so the
-    // link must exist before the server is created.
-    const server = utils.http({ dev: false });
+  test("should still serve a file that stays inside", async () => {
+    const dir = dirWithEscapingLink();
+    const server = utils.http(opts, dir);
 
     try {
-      const res = await server.send("GET", "/escape.txt");
-      assert.equal(res.status, 404);
+      const res = await server.send("GET", "/inside.txt");
+      assert.equal(res.status, 200);
+      assert.equal(await res.text(), "inside\n");
     } finally {
       server.close();
-      unlinkSync(link);
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
The symlink tests created `escape.txt` inside `tests/public/`, the fixture directory every other suite serves. Spec files run in parallel, so creating or removing that entry races the `totalist` scan each production-mode server performs over the same directory, and the scan fails with `ENOENT` on a file that vanished between `readdir` and `stat`.

The fixture now gets a temporary directory of its own, containing both the escaping link and a regular file, so nothing else can observe it mid-write. The contained file is asserted too: it pins that containment rejects only what escapes, and it exercises the resolved-root path, since a temporary directory is itself commonly a symlink.