### PR TITLE
fix(node): report failures while sending the response instead of swallowing them

### DIFF
--- a/.changeset/brave-moons-shout.md
+++ b/.changeset/brave-moons-shout.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/node": patch
+---
+
+fix(node): report failures while sending the response instead of swallowing them

--- a/packages/adapter-express/tests/node-send-errors.spec.ts
+++ b/packages/adapter-express/tests/node-send-errors.spec.ts
@@ -1,0 +1,86 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { UniversalHandler } from "@universal-middleware/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHandler } from "../src/index.js";
+
+// `sendResponse` swallowed every failure of the response pipeline, so a body
+// that threw mid-stream produced a truncated response and no trace of why.
+//
+// Ported from srvx#243.
+
+describe("sendResponse — failures while sending", () => {
+  const servers: ReturnType<typeof createServer>[] = [];
+
+  afterEach(() => {
+    for (const server of servers.splice(0)) server.close();
+    vi.restoreAllMocks();
+  });
+
+  function serve(handler: UniversalHandler): number {
+    const server = createServer(createHandler(() => handler)());
+    servers.push(server);
+    server.listen();
+    return (server.address() as AddressInfo).port;
+  }
+
+  it("reports a body stream that fails mid-response", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const boom = new Error("body exploded");
+
+    const port = serve(
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("partial"));
+            },
+            pull(controller) {
+              controller.error(boom);
+            },
+          }),
+          { headers: { "content-type": "text/plain" } },
+        ),
+    );
+
+    // The response is already committed when the body fails, so the client sees
+    // a truncated body rather than an error status — the log is the only signal.
+    await fetch(`http://localhost:${port}/`)
+      .then((res) => res.text())
+      .catch(() => undefined);
+
+    expect(consoleError).toHaveBeenCalledWith(boom);
+  });
+
+  it("stays quiet when the client disconnects mid-response", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let stop = false;
+
+    const port = serve(
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            async pull(controller) {
+              if (stop) return controller.close();
+              controller.enqueue(new Uint8Array(16 * 1024));
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            },
+          }),
+          { headers: { "content-type": "application/octet-stream" } },
+        ),
+    );
+
+    const ctrl = new AbortController();
+    try {
+      const res = await fetch(`http://localhost:${port}/`, { signal: ctrl.signal });
+      const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+      await reader.read();
+      ctrl.abort();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      stop = true;
+    }
+  });
+});

--- a/packages/node/src/response.ts
+++ b/packages/node/src/response.ts
@@ -61,11 +61,23 @@ export async function sendResponse(fetchResponse: Response, nodeResponse: Server
 
   if (body) {
     const { pipeline } = await import("node:stream/promises");
-    await pipeline(body, nodeResponse).catch(() => {});
+    await pipeline(body, nodeResponse).catch((error) => {
+      if (!isClientGone(error)) console.error(error);
+    });
   } else {
     nodeResponse.setHeader("content-length", "0");
     nodeResponse.end();
   }
+}
+
+/**
+ * A client disconnecting mid-response is routine and says nothing about the
+ * application; anything else reaching here is a real failure — an invalid
+ * header, a source stream that threw — and would otherwise vanish silently.
+ */
+function isClientGone(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ECONNRESET" || code === "EPIPE" || code === "ERR_STREAM_PREMATURE_CLOSE";
 }
 
 function getFullUrl(pathnameOrFull: string, req: IncomingMessage): string {


### PR DESCRIPTION
## Problem

`sendResponse` ended the response pipeline with `.catch(() => {})`, discarding every failure: a body stream that threw mid-response, an invalid header, a write that could not complete. The client saw a truncated body and the server left no trace of why.

## Fix

Failures are logged via `console.error`, matching how the express adapter already reports handler errors. The one routine failure — a client disconnecting mid-response — stays quiet, since it says nothing about the application and would otherwise turn every cancelled download into log noise (`ECONNRESET` / `EPIPE` / `ERR_STREAM_PREMATURE_CLOSE`).

## Tests

`packages/adapter-express/tests/node-send-errors.spec.ts` — a body stream that fails mid-response is logged; a client that aborts is not. The first test fails against `main` (the error was swallowed); both pass here.

Typecheck and Biome clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Response-stream failures are now reported instead of being silently ignored.
  * Expected client disconnects remain quiet to avoid unnecessary error logs.
* **Release**
  * Published a patch release for the Node middleware package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->