### PR TITLE
fix(express): report HTTP version, raw headers and completion on the synthetic request

### DIFF
--- a/.changeset/tall-eels-tickle.md
+++ b/.changeset/tall-eels-tickle.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/express": patch
+---
+
+fix(express): report HTTP version, raw headers and completion on the synthetic request

--- a/packages/adapter-express/src/utils.ts
+++ b/packages/adapter-express/src/utils.ts
@@ -107,12 +107,29 @@ export function createIncomingMessage(request: Request): IncomingMessage {
 
   // Express reads connection metadata off `req.socket` (e.g. `req.protocol` -> `socket.encrypted`);
   // a synthetic request has no socket, so stub the field it reads to avoid a throw.
-  return Object.assign(body, {
+  const message = Object.assign(body, {
     url: url.pathname + url.search,
     method: request.method,
     headers,
-    socket: { encrypted: url.protocol === "https:" },
+    rawHeaders: Object.entries(headers).flat(),
+    // No wire sits behind this message, but consumers still read a version off
+    // it — morgan's `:http-version` among them. HTTP/1.1 is the semantics the
+    // emulated Node API describes.
+    httpVersion: "1.1",
+    httpVersionMajor: 1,
+    httpVersionMinor: 1,
+    complete: !request.body,
+    // `readable` matters as much as `encrypted`: `on-finished` — which body
+    // parsers consult before reading — treats a message whose socket is not
+    // readable as already finished, and would skip the body entirely.
+    socket: { encrypted: url.protocol === "https:", readable: true },
   }) as unknown as IncomingMessage;
+
+  message.once("end", () => {
+    message.complete = true;
+  });
+
+  return message;
 }
 
 /**

--- a/packages/adapter-express/tests/connect-to-web.spec.ts
+++ b/packages/adapter-express/tests/connect-to-web.spec.ts
@@ -324,4 +324,34 @@ describe("createIncomingMessage", () => {
     expect(req.socket).toBeDefined();
     expect((req.socket as unknown as { encrypted: boolean }).encrypted).toBe(true);
   });
+
+  it("reports an HTTP version, as loggers like morgan read it", () => {
+    const req = createIncomingMessage(new Request("http://localhost/"));
+    expect(req.httpVersion).toBe("1.1");
+    expect(req.httpVersionMajor).toBe(1);
+    expect(req.httpVersionMinor).toBe(1);
+  });
+
+  it("exposes rawHeaders as name/value pairs", () => {
+    const req = createIncomingMessage(new Request("http://localhost/", { headers: { "x-one": "1", "x-two": "2" } }));
+    expect(req.rawHeaders).toContain("x-one");
+    expect(req.rawHeaders[req.rawHeaders.indexOf("x-one") + 1]).toBe("1");
+    expect(req.rawHeaders[req.rawHeaders.indexOf("x-two") + 1]).toBe("2");
+  });
+
+  it("marks a bodyless request complete straight away", () => {
+    expect(createIncomingMessage(new Request("http://localhost/")).complete).toBe(true);
+  });
+
+  it("marks a request with a body complete only once the body has been read", async () => {
+    const req = createIncomingMessage(new Request("http://localhost/", { method: "POST", body: "hello" }));
+    expect(req.complete).toBe(false);
+
+    await new Promise((resolve) => {
+      req.on("data", () => {});
+      req.on("end", resolve);
+    });
+
+    expect(req.complete).toBe(true);
+  });
 });


### PR DESCRIPTION
## Problem

`createIncomingMessage` (the synthetic `IncomingMessage` behind `connectToWeb`) set only `url`, `method`, `headers` and a socket stub. Consumers reading the rest of the `IncomingMessage` contract saw `undefined`: morgan's `:http-version` token, anything walking `rawHeaders`, and any check of whether the request body had been fully received.

## Fix

The message now reports `httpVersion` (`"1.1"`, the semantics the emulated Node API describes), `rawHeaders` as name/value pairs, and `complete` — `true` immediately for a bodyless request, flipped on `end` once a body has been read.

The socket stub gains `readable: true` alongside `encrypted`. This is load-bearing: `on-finished`, which body parsers consult before reading, only takes its `IncomingMessage` branch once `complete` is a boolean, and that branch treats a message whose socket is not `readable` as already finished — which would have silently emptied every parsed body. Caught by the existing `express.json()` test.

## Tests

Extends `createIncomingMessage` coverage in `connect-to-web.spec.ts`: HTTP version reported, `rawHeaders` exposed, `complete` true for a bodyless request and false-until-read for one with a body. The full express suite (including the `express.json()` body-parser test) stays green.

Typecheck and Biome clean.