### PR TITLE
fix(compress): honor `*` in `Accept-Encoding`

### DIFF
--- a/.changeset/olive-books-guess.md
+++ b/.changeset/olive-books-guess.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/compress": patch
+---
+
+fix(compress): honor `*` in `Accept-Encoding`

--- a/packages/compress/src/encoding-header.ts
+++ b/packages/compress/src/encoding-header.ts
@@ -62,28 +62,28 @@ function parseEncoding(str: string) {
 }
 
 export function chooseBestEncoding(request: Request, availableEncodings: readonly string[]) {
-  let bestEncoding: AcceptEncoding | null = null;
-
   if (availableEncodings.length === 0) return null;
 
   const header = request.headers.get("Accept-Encoding");
   if (!header) return null;
 
   const parsed = parseAcceptEncodingHeader(header);
+  // RFC 9110 §12.5.3: "*" stands for every coding the header does not name.
+  const wildcard = parsed.get("*");
 
-  for (const enc of availableEncodings) {
-    const encodingEntry = parsed.get(enc);
+  let bestEncoding: AcceptEncoding | null = null;
+  for (const encoding of availableEncodings) {
+    const match = parsed.get(encoding) ?? wildcard;
+    // A qvalue of 0 means "not acceptable".
+    if (!match || match.q <= 0) continue;
 
-    // RFC 9110 §12.5.3: a qvalue of 0 means "not acceptable".
-    if (encodingEntry && encodingEntry.q > 0) {
-      // If no best encoding found or current encoding has higher q-value or better index
-      if (
-        !bestEncoding ||
-        encodingEntry.q > bestEncoding.q ||
-        (encodingEntry.q === bestEncoding.q && encodingEntry.index < bestEncoding.index)
-      ) {
-        bestEncoding = encodingEntry;
-      }
+    const candidate = { encoding, q: match.q, index: match.index };
+    if (
+      !bestEncoding ||
+      candidate.q > bestEncoding.q ||
+      (candidate.q === bestEncoding.q && candidate.index < bestEncoding.index)
+    ) {
+      bestEncoding = candidate;
     }
   }
 

--- a/packages/compress/test/accept-encoding.spec.ts
+++ b/packages/compress/test/accept-encoding.spec.ts
@@ -31,6 +31,24 @@ describe("chooseBestEncoding :: q=0 is a refusal", () => {
   });
 });
 
+describe("chooseBestEncoding :: the wildcard", () => {
+  it("matches a coding the header does not name", () => {
+    expect(chooseBestEncoding(req("*"), ["gzip", "deflate"])).toBe("gzip");
+  });
+
+  it("loses to a coding the header names explicitly", () => {
+    expect(chooseBestEncoding(req("deflate;q=1, *;q=0.5"), ["gzip", "deflate"])).toBe("deflate");
+  });
+
+  it("does not revive a coding that was refused explicitly", () => {
+    expect(chooseBestEncoding(req("gzip;q=0, *"), ["gzip", "deflate"])).toBe("deflate");
+  });
+
+  it("refuses everything unnamed when the wildcard itself is refused", () => {
+    expect(chooseBestEncoding(req("*;q=0"), ["gzip", "deflate"])).toBeUndefined();
+  });
+});
+
 describe("EncodingGuesser :: q=0 is a refusal", () => {
   it("should not compress when the only offered encoding was refused", () => {
     expect(new EncodingGuesser(req("gzip;q=0")).encoding).toBeNull();
@@ -38,5 +56,9 @@ describe("EncodingGuesser :: q=0 is a refusal", () => {
 
   it("should still compress with an encoding that was not refused", () => {
     expect(new EncodingGuesser(req("br;q=0, gzip")).encoding).toBe("gzip");
+  });
+
+  it("should compress when the client accepts any encoding", () => {
+    expect(new EncodingGuesser(req("*")).encoding).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

`chooseBestEncoding` only ever looked for an exact match, so `Accept-Encoding: *` — which RFC 9110 §12.5.3 defines as standing for every coding the header does not name — matched nothing and the response went out uncompressed.

## Fix

An available coding falls back to the wildcard's qvalue when the header does not name it explicitly. Named entries still win, so:

- `*` → compresses with the server's preferred coding
- `deflate;q=1, *;q=0.5` → `deflate` (the named entry outranks the wildcard)
- `gzip;q=0, *` → refuses gzip, allows the rest
- `*;q=0` → refuses everything unnamed

The chosen coding is also carried explicitly rather than read back off the matched header entry, which for a wildcard match would otherwise have returned the literal `*`.

## Tests

Four `chooseBestEncoding` wildcard cases plus one `EncodingGuesser` case in `accept-encoding.spec.ts`. Full compress suite: 58 passed.

Typecheck and Biome clean.