### PR TITLE
fix(sirv): honor `If-Modified-Since` and answer 304 with its validators

### DIFF
--- a/.changeset/wild-cows-repeat.md
+++ b/.changeset/wild-cows-repeat.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/sirv": patch
+---
+
+fix(sirv): honor `If-Modified-Since` and answer 304 with its validators

--- a/packages/sirv/src/middleware.ts
+++ b/packages/sirv/src/middleware.ts
@@ -200,7 +200,6 @@ function toHeaders(name: string, stats: fs.Stats, isEtag: boolean): Record<strin
 
 // Create a universal middleware that accepts standard Request
 function createUniversalMiddleware(
-  isEtag: boolean,
   isSPA: boolean,
   ignores: RegExp[],
   lookup: (uri: string, extns: string[]) => FileData | undefined,
@@ -233,20 +232,44 @@ function createUniversalMiddleware(
     const data = lookup(pathname, extns) || (isSPA && !isMatch(pathname, ignores) && lookup(fallback, extns));
     if (!data) return isNotFound ? isNotFound(request) : undefined;
 
-    // biome-ignore lint/complexity/useLiteralKeys: ignored
-    if (isEtag && request.headers.get("if-none-match") === data.headers["ETag"]) {
-      return new Response(null, { status: 304 });
+    if (gzips || brots) {
+      data.headers.Vary = "Accept-Encoding";
     }
 
-    if (gzips || brots) {
-      // biome-ignore lint/complexity/useLiteralKeys: ignored
-      data.headers["Vary"] = "Accept-Encoding";
+    if (isNotModified(request, data.headers)) {
+      return new Response(null, { status: 304, headers: revalidationHeaders(data.headers) });
     }
 
     const response = send(request, data.abs, data.stats, data.headers);
     setHeaders(response, pathname, data.stats);
     return response;
   };
+}
+
+/** RFC 9110 §13.2.2: `If-None-Match` is conclusive, so `If-Modified-Since` is only consulted in its absence. */
+function isNotModified(request: Request, headers: Record<string, string>): boolean {
+  const ifNoneMatch = request.headers.get("if-none-match");
+  if (ifNoneMatch) {
+    const etag = headers.ETag;
+    if (!etag) return false;
+    // Weak comparison: the `W/` prefix takes no part in the match.
+    const opaqueTag = (tag: string) => tag.trim().replace(/^W\//, "");
+    return ifNoneMatch === "*" || ifNoneMatch.split(",").some((tag) => opaqueTag(tag) === opaqueTag(etag));
+  }
+
+  const ifModifiedSince = request.headers.get("if-modified-since");
+  if (!ifModifiedSince) return false;
+  // An unparseable date yields NaN, which compares false and serves the file.
+  return Date.parse(headers["Last-Modified"]) <= Date.parse(ifModifiedSince);
+}
+
+/** A 304 repeats the validators and caching directives, and none of the representation headers (RFC 9110 §15.4.5). */
+function revalidationHeaders(headers: Record<string, string>): Record<string, string> {
+  const repeated: Record<string, string> = {};
+  for (const name of ["ETag", "Last-Modified", "Cache-Control", "Vary"]) {
+    if (headers[name]) repeated[name] = headers[name];
+  }
+  return repeated;
 }
 
 /** Whether the client accepts one of `codings`. RFC 9110 §12.5.3: a qvalue of 0 means "not acceptable". */
@@ -320,7 +343,6 @@ export default function serveStatic(dir?: string, opts: ServeOptions = {}): Univ
     : (uri: string, extns: string[]) => viaCache(FILES, uri, extns);
 
   return createUniversalMiddleware(
-    isEtag,
     isSPA,
     ignores,
     lookupFn,

--- a/packages/sirv/tests/conditional.spec.ts
+++ b/packages/sirv/tests/conditional.spec.ts
@@ -1,0 +1,166 @@
+import { assert, describe, test } from "vitest";
+import * as utils from "./helpers";
+
+// Every response carries `Last-Modified`, but `If-Modified-Since` was never
+// consulted, so a client holding a fresh copy was always sent the whole file
+// again. Ported from srvx#269.
+
+const FILE = "/bundle.67329.js";
+
+describe("conditional requests :: If-Modified-Since", () => {
+  test("should answer 304 when the copy the client holds is current", async () => {
+    const server = utils.http();
+
+    try {
+      const first = await server.send("GET", FILE);
+      const lastModified = first.headers.get("last-modified") as string;
+
+      const res = await server.send("GET", FILE, { headers: { "If-Modified-Since": lastModified } });
+      assert.equal(res.status, 304);
+      assert.equal(await res.text(), "");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should serve the file when the client's copy is older", async () => {
+    const server = utils.http();
+
+    try {
+      const first = await server.send("GET", FILE);
+      const stale = new Date(Date.parse(first.headers.get("last-modified") as string) - 60_000).toUTCString();
+
+      const res = await server.send("GET", FILE, { headers: { "If-Modified-Since": stale } });
+      assert.equal(res.status, 200);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should ignore an unparseable date", async () => {
+    const server = utils.http();
+
+    try {
+      const res = await server.send("GET", FILE, { headers: { "If-Modified-Since": "not a date" } });
+      assert.equal(res.status, 200);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("conditional requests :: If-None-Match", () => {
+  test("should match a list containing the current tag", async () => {
+    const server = utils.http({ etag: true });
+
+    try {
+      const etag = (await server.send("GET", FILE)).headers.get("etag") as string;
+
+      const res = await server.send("GET", FILE, { headers: { "If-None-Match": `W/"stale", ${etag}` } });
+      assert.equal(res.status, 304);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should match a strong tag against our weak one", async () => {
+    const server = utils.http({ etag: true });
+
+    try {
+      const etag = (await server.send("GET", FILE)).headers.get("etag") as string;
+
+      // RFC 9110 §13.1.2 compares `If-None-Match` weakly, so `W/` does not count.
+      const res = await server.send("GET", FILE, { headers: { "If-None-Match": etag.replace("W/", "") } });
+      assert.equal(res.status, 304);
+    } finally {
+      server.close();
+    }
+  });
+
+  test('should match "*"', async () => {
+    const server = utils.http({ etag: true });
+
+    try {
+      const res = await server.send("GET", FILE, { headers: { "If-None-Match": "*" } });
+      assert.equal(res.status, 304);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should take precedence over a matching If-Modified-Since", async () => {
+    const server = utils.http({ etag: true });
+
+    try {
+      const first = await server.send("GET", FILE);
+      const lastModified = first.headers.get("last-modified") as string;
+
+      // The date says "unchanged", the tag says otherwise; the tag decides.
+      const res = await server.send("GET", FILE, {
+        headers: { "If-None-Match": 'W/"stale"', "If-Modified-Since": lastModified },
+      });
+      assert.equal(res.status, 200);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should be ignored when no ETag is served", async () => {
+    const server = utils.http({ etag: false });
+
+    try {
+      const res = await server.send("GET", FILE, { headers: { "If-None-Match": "*" } });
+      assert.equal(res.status, 200);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("conditional requests :: the 304 itself", () => {
+  test("should repeat the validators and caching directives", async () => {
+    const server = utils.http({ etag: true, maxAge: 100 });
+
+    try {
+      const first = await server.send("GET", FILE);
+      const etag = first.headers.get("etag") as string;
+
+      const res = await server.send("GET", FILE, { headers: { "If-None-Match": etag } });
+      assert.equal(res.status, 304);
+      assert.equal(res.headers.get("etag"), etag);
+      assert.equal(res.headers.get("last-modified"), first.headers.get("last-modified"));
+      assert.equal(res.headers.get("cache-control"), "public,max-age=100");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should not describe a representation it is not sending", async () => {
+    const server = utils.http({ etag: true });
+
+    try {
+      const etag = (await server.send("GET", FILE)).headers.get("etag") as string;
+
+      const res = await server.send("GET", FILE, { headers: { "If-None-Match": etag } });
+      assert.equal(res.status, 304);
+      assert.notOk(res.headers.get("content-type"));
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should keep Vary so a shared cache still keys on the encoding", async () => {
+    const server = utils.http({ etag: true, gzip: true });
+
+    try {
+      const headers = { "Accept-Encoding": "gzip" };
+      const etag = (await server.send("GET", "/", { headers })).headers.get("etag") as string;
+
+      const res = await server.send("GET", "/", { headers: { ...headers, "If-None-Match": etag } });
+      assert.equal(res.status, 304);
+      assert.equal(res.headers.get("vary"), "Accept-Encoding");
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Every response carries `Last-Modified`, but only `If-None-Match` was ever consulted — and only when `etag` was enabled. A client holding a current copy was sent the whole file again on every request. The `If-None-Match` handling was also a single exact-string comparison, so a header list, `*`, or a strong-tag echo of our weak validator all missed.

## Fix

- **`If-Modified-Since`** is honored, comparing against `Last-Modified` at second precision. An unparseable date yields `NaN`, which serves the file rather than erroring.
- **Precedence** (RFC 9110 §13.2.2): when both validators are present, `If-None-Match` decides — a tag that fails to match is conclusive and the date is not consulted.
- **`If-None-Match`** now handles what the header allows: a comma list, `*`, and the weak comparison that ignores the `W/` prefix on both sides.
- **The 304** repeats `ETag`, `Last-Modified`, `Cache-Control` and `Vary` (RFC 9110 §15.4.5), so revalidating refreshes the client's stored freshness instead of dropping it. `Vary` is now set before the conditional check for exactly this reason.

`isEtag` is dropped from `createUniversalMiddleware`'s parameters, since the tag check moved into the shared helper.

## Tests

`packages/sirv/tests/conditional.spec.ts` — 11 cases: `If-Modified-Since` 304/200/unparseable, `If-None-Match` list/`*`/weak-strong, precedence over a matching date, ignored when no ETag is served, and the 304 carrying its validators while omitting representation headers. Six fail against `main`; the rest are guards. Full sirv suite: 110 passed.

Typecheck and Biome clean.