### PR TITLE
docs(vercel): explain why the leftmost X-Forwarded-For is the client

### DIFF
--- a/packages/adapter-vercel/src/utils/hattip.ts
+++ b/packages/adapter-vercel/src/utils/hattip.ts
@@ -4,6 +4,9 @@ export function createContext(request: Request, platformName: string): AdapterRe
   return {
     request,
     // TODO: Support the newer `Forwarded` standard header
+    // The leftmost entry is the client: Vercel overwrites `X-Forwarded-For` at
+    // its edge and does not forward external IPs, so a client cannot prepend a
+    // spoofed value here. https://vercel.com/docs/headers/request-headers
     ip: (request.headers.get("x-forwarded-for") || "").split(",", 1)[0].trim(),
     waitUntil() {},
     passThrough() {},


### PR DESCRIPTION
## Context

The node and express adapters were changed (#332) to read the **rightmost** `X-Forwarded-*` value, because a client can prepend spoofed entries to a header proxies append to.

`adapter-vercel` reads the **leftmost** `x-forwarded-for` for `ip`. That looks like the same bug, and a future cleanup could easily "correct" it into one.

## Why it is correct here

Per [Vercel's docs](https://vercel.com/docs/headers/request-headers):

> we currently **overwrite** the `X-Forwarded-For` header and **do not forward external IPs**. This restriction is in place to prevent IP spoofing.

Vercel replaces the header at its edge, so the leftmost entry is the real client and nothing a client sends survives to reach this adapter. The leftmost read is right.

## Change

A source comment recording the invariant and linking the docs. No behavior change, no changeset.