### PR TITLE
feat(node): resolve the origin from the `Forwarded` header (RFC 7239)

### DIFF
--- a/.changeset/lucky-pandas-drum.md
+++ b/.changeset/lucky-pandas-drum.md
@@ -1,0 +1,5 @@
+---
+"@universal-middleware/node": patch
+---
+
+feat(node): resolve the origin from the `Forwarded` header (RFC 7239)

--- a/packages/adapter-express/tests/node-forwarded.spec.ts
+++ b/packages/adapter-express/tests/node-forwarded.spec.ts
@@ -71,6 +71,64 @@ describe("createRequestAdapter — X-Forwarded-* resolution", () => {
   });
 });
 
+describe("createRequestAdapter — Forwarded (RFC 7239) resolution", () => {
+  const adapt = (headers: Record<string, string>) =>
+    createRequestAdapter({ trustProxy: true })(fakeReq(headers, "/p"), fakeRes());
+
+  it("reads proto and host from a single element", () => {
+    const request = adapt({ host: "internal", forwarded: "for=192.0.2.60;proto=https;host=public.example" });
+    expect(request.url).toBe("https://public.example/p");
+  });
+
+  it("reads the nearest (rightmost) element when the chain has several", () => {
+    const request = adapt({
+      host: "internal",
+      forwarded: "host=evil.test;proto=http, host=real.example;proto=https",
+    });
+    expect(request.url).toBe("https://real.example/p");
+  });
+
+  it("treats parameter names case-insensitively", () => {
+    const request = adapt({ host: "internal", forwarded: "Proto=https;Host=public.example" });
+    expect(request.url).toBe("https://public.example/p");
+  });
+
+  it("does not split on a comma inside a quoted value", () => {
+    // A quoted IPv6 `for` in the nearest element must not be read as two elements.
+    const request = adapt({ host: "internal", forwarded: 'for="[2001:db8::1]:4711";proto=https;host=public.example' });
+    expect(request.url).toBe("https://public.example/p");
+  });
+
+  it("unquotes a quoted host", () => {
+    const request = adapt({ host: "internal", forwarded: 'proto=https;host="public.example:8443"' });
+    expect(request.url).toBe("https://public.example:8443/p");
+  });
+
+  it("falls back to the connection when the nearest element omits the param", () => {
+    // The nearest proxy set only `for`, so proto/host come from the socket and Host.
+    const request = adapt({ host: "real.example", forwarded: "for=192.0.2.60" });
+    expect(request.url).toBe("http://real.example/p");
+  });
+
+  it("takes precedence over X-Forwarded-* and does not mix the two", () => {
+    const request = adapt({
+      host: "internal",
+      forwarded: "proto=https;host=from-forwarded.example",
+      "x-forwarded-host": "from-legacy.example",
+      "x-forwarded-proto": "http",
+    });
+    expect(request.url).toBe("https://from-forwarded.example/p");
+  });
+
+  it("is ignored entirely when trustProxy is off", () => {
+    const request = createRequestAdapter({ trustProxy: false })(
+      fakeReq({ host: "real.example", forwarded: "host=evil.test;proto=https" }, "/p"),
+      fakeRes(),
+    );
+    expect(request.url).toBe("http://real.example/p");
+  });
+});
+
 describe("responseAdapter — redirect Location must not be attacker-controlled", () => {
   // `getFullUrl` absolutized a relative Location using X-Forwarded-Host with no
   // `trustProxy` gate at all, turning a local redirect into an open redirect.
@@ -104,6 +162,25 @@ describe("responseAdapter — redirect Location must not be attacker-controlled"
     const location = response.headers.get("location") as string;
 
     expect(new URL(location).protocol).toBe("http:");
+  });
+
+  it("builds the redirect origin from Forwarded when trustProxy is on", () => {
+    process.env.TRUST_PROXY = "1";
+    try {
+      const incoming = {
+        headers: { host: "internal", forwarded: "proto=https;host=public.example" },
+        socket: {},
+      } as unknown as IncomingMessage;
+
+      const res = new ServerResponse(incoming);
+      res.statusCode = 302;
+      res.setHeader("location", "/next");
+
+      const location = responseAdapter(res).headers.get("location") as string;
+      expect(location).toBe("https://public.example/next");
+    } finally {
+      delete process.env.TRUST_PROXY;
+    }
   });
 
   it("leaves an absolute Location untouched", () => {

--- a/packages/node/src/forwarded.ts
+++ b/packages/node/src/forwarded.ts
@@ -1,20 +1,77 @@
 import type { IncomingHttpHeaders } from "node:http";
 import { env } from "./const.js";
 
-/** Whether `X-Forwarded-*` may be believed at all. */
+/** Whether the forwarding headers may be believed at all. */
 export function trustsProxy(): boolean {
   return env.TRUST_PROXY === "1";
 }
 
-// TODO: Support the newer `Forwarded` standard header
 /**
- * The `X-Forwarded-<name>` value contributed by the nearest proxy — the rightmost
- * entry, since proxies append and the leftmost is whatever the client sent.
+ * The `proto`/`host` contributed by the nearest proxy.
+ *
+ * RFC 7239's `Forwarded` is preferred over the older `X-Forwarded-*` when
+ * present. Either way the nearest proxy is the rightmost entry, since proxies
+ * append and the leftmost is whatever the client sent.
  */
-export function forwardedValue(headers: IncomingHttpHeaders, name: string): string | undefined {
-  const value = headers[`x-forwarded-${name}`];
-  if (!value) return undefined;
+export function forwardedValue(headers: IncomingHttpHeaders, param: "proto" | "host"): string | undefined {
+  const forwarded = headers.forwarded;
+  // A trusted proxy that speaks `Forwarded` is authoritative: its element does
+  // not fall through to `X-Forwarded-*`, so one cannot be used to spoof the
+  // other. An absent param resolves from the connection instead.
+  if (forwarded) return nearestForwardedElement(String(forwarded))[param];
 
+  return rightmostListValue(headers[`x-forwarded-${param}`]);
+}
+
+function rightmostListValue(value: string | string[] | undefined): string | undefined {
+  if (!value) return undefined;
   const hops = String(value).split(",");
   return hops[hops.length - 1].trim() || undefined;
+}
+
+/** Parses the params (RFC 7239 §4) of the nearest — rightmost — element of a `Forwarded` header. */
+function nearestForwardedElement(header: string): { proto?: string; host?: string } {
+  const elements = splitOutsideQuotes(header, ",");
+  const nearest = elements[elements.length - 1];
+
+  const params: { proto?: string; host?: string } = {};
+  for (const pair of splitOutsideQuotes(nearest, ";")) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    const name = pair.slice(0, eq).trim().toLowerCase();
+    if (name === "proto" || name === "host") {
+      params[name] = unquote(pair.slice(eq + 1).trim()) || undefined;
+    }
+  }
+  return params;
+}
+
+/** Splits on `separator`, ignoring occurrences inside a quoted-string (where an IPv6 `for` may sit). */
+function splitOutsideQuotes(value: string, separator: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quoted = false;
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (quoted && char === "\\") {
+      current += char + (value[++i] ?? "");
+    } else if (char === '"') {
+      quoted = !quoted;
+      current += char;
+    } else if (char === separator && !quoted) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
+function unquote(value: string): string {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\(.)/g, "$1");
+  }
+  return value;
 }

--- a/packages/node/src/request.ts
+++ b/packages/node/src/request.ts
@@ -38,20 +38,20 @@ export interface NodeRequestAdapterOptions {
    * It defaults to `process.env.ORIGIN`. If neither is set,
    * the origin is computed from the protocol and hostname.
    * To determine the protocol, `req.protocol` is tried first.
-   * If `trustProxy` is set, `X-Forwarded-Proto` header is used.
+   * If `trustProxy` is set, the forwarding headers are used.
    * Otherwise, `req.socket.encrypted` is used.
-   * To determine the hostname, `X-Forwarded-Host`
-   * (if `trustProxy` is set) or `Host` header is used.
+   * To determine the hostname, the forwarding headers
+   * (if `trustProxy` is set) or the `Host` header is used.
    */
   origin?: string;
   /**
-   * Whether to trust `X-Forwarded-*` headers. `X-Forwarded-Proto`
-   * and `X-Forwarded-Host` are used to determine the origin when
-   * `origin` and `process.env.ORIGIN` are not set. `X-Forwarded-For`
-   * is used to determine the IP address. The rightmost value is used
-   * if multiple values are set, as that is the one contributed by the
-   * nearest proxy. Defaults to true if `process.env.TRUST_PROXY`
-   * is set to `1`, otherwise false.
+   * Whether to trust the forwarding headers. The standard `Forwarded`
+   * header (RFC 7239) is used when present, otherwise `X-Forwarded-*`:
+   * `proto`/`host` determine the origin when `origin` and
+   * `process.env.ORIGIN` are not set, and `for` determines the IP address.
+   * The rightmost entry is used when several are present, as that is the
+   * one contributed by the nearest proxy. Defaults to true if
+   * `process.env.TRUST_PROXY` is set to `1`, otherwise false.
    */
   trustProxy?: boolean;
 }


### PR DESCRIPTION
## What

`forwardedValue` understood only `X-Forwarded-*`, with a standing `// TODO: Support the newer Forwarded standard header`. It now parses RFC 7239's `Forwarded` header and prefers it when present, falling back to `X-Forwarded-*` otherwise.

```
Forwarded: for=192.0.2.60;proto=https;host=public.example
Forwarded: host=evil.test;proto=http, host=real.example;proto=https   → real.example (nearest element)
Forwarded: for="[2001:db8::1]:4711";proto=https;host=public.example    → the quoted for does not split the element
```

## How

Parsing follows §4: comma-separated elements, semicolon-separated `name=value` pairs, case-insensitive names, quoted values unquoted (with backslash escapes). Splitting is quote-aware so a quoted IPv6 `for` — the one place a comma or semicolon legitimately appears inside a value — cannot break element boundaries.

The security model is unchanged from the `X-Forwarded-*` work (#332): the **rightmost** element is the nearest — trusted — proxy, since proxies append and the leftmost is the client's. Two deliberate choices:

- **`Forwarded` is authoritative and does not mix with `X-Forwarded-*`.** When present, only it is read; a param the nearest element omits resolves from the connection (`socket.encrypted` / `Host`), never from the legacy header. Mixing the two per-hop would let one spoof the other.
- **Everything stays behind `trustProxy`.** The call sites in `createRequestAdapter` and `responseAdapter` are untouched; only what `forwardedValue` reads has grown.

The `NodeRequestAdapterOptions.trustProxy` / `origin` docs are updated to describe both headers.

## Scope

The `X-Forwarded-For`-based `ip` in `adapter-vercel` keeps its own TODO. That value is one Vercel **overwrites** at its edge to prevent spoofing (see #339), so reading a client-supplied `Forwarded` there would reintroduce exactly that vector. `Forwarded` support only belongs where it is gated by `trustProxy`.

## Tests

Eight `Forwarded` cases in `node-forwarded.spec.ts`: single element, nearest-of-many, case-insensitivity, the quoted-IPv6 non-split, quoted-host unquoting, fallback-to-connection on a missing param, precedence over `X-Forwarded-*`, and `trustProxy: false` ignoring it — plus a `responseAdapter` redirect case. Two fail against `main`'s parser (precedence, redirect) and the rest error without it. Full express suite: 101 passed.

Typecheck and Biome clean.
