### PR TITLE
fix: address code-review findings across node, express and sirv

### DIFF
--- a/.changeset/lemon-carts-melt.md
+++ b/.changeset/lemon-carts-melt.md
@@ -1,0 +1,12 @@
+---
+"@universal-middleware/sirv": patch
+---
+
+fix(sirv): correct range, encoding, and dev-mode edge cases
+
+A backwards range (`bytes=5-2`) is ignored and the full file served (RFC 9110
+§14.2) instead of answering 416, which is now reserved for ranges past EOF.
+`Accept-Encoding` negotiation honors the `*` wildcard (an explicit coding still
+overrides it) and treats a valueless `q` as acceptable. And a missing directory
+in `dev` mode no longer throws at construction, so a watch/lazy build that
+produces the directory later can start.

--- a/.changeset/soft-rings-flow.md
+++ b/.changeset/soft-rings-flow.md
@@ -1,0 +1,11 @@
+---
+"@universal-middleware/express": patch
+---
+
+fix(express): make the synthetic request socket a real EventEmitter
+
+`connectToWeb`'s synthetic `IncomingMessage` used a bare-object socket stub. On a
+body parser's drain path (e.g. an oversized body → 413), `on-finished` attaches
+an `error`/`close` listener to the socket, which threw `ee.on is not a function`
+and crashed the request instead of returning the error status. The stub is now an
+`EventEmitter`.

--- a/.changeset/witty-otters-hunt.md
+++ b/.changeset/witty-otters-hunt.md
@@ -1,0 +1,11 @@
+---
+"@universal-middleware/node": patch
+---
+
+fix(node): resolve forwarded `proto`/`host` like Express `trust proxy`, and broaden client-abort detection
+
+`X-Forwarded-*` is now authoritative and read as its first (client-facing) value,
+matching Express; the RFC 7239 `Forwarded` header only fills a param the legacy
+header omits, so a passed-through client `Forwarded` can no longer override what
+the proxy set. Send-error logging also treats `ERR_STREAM_DESTROYED`/`ABORT_ERR`
+as routine client aborts, and the HEAD check guards a possibly-absent `req`.

--- a/packages/adapter-express/src/utils.ts
+++ b/packages/adapter-express/src/utils.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { type IncomingMessage, type OutgoingHttpHeader, type OutgoingHttpHeaders, ServerResponse } from "node:http";
 import { PassThrough, Readable } from "node:stream";
 import type { RuntimeAdapterTarget } from "@universal-middleware/core";
@@ -117,9 +118,11 @@ export function createIncomingMessage(request: Request): IncomingMessage {
     httpVersionMajor: 1,
     httpVersionMinor: 1,
     complete: !request.body,
-    // `readable` is load-bearing: `on-finished`, which body parsers consult before
-    // reading, treats a non-readable socket as already finished and skips the body.
-    socket: { encrypted: url.protocol === "https:", readable: true },
+    // A real EventEmitter, not a bare object: `on-finished` (which body parsers
+    // consult) attaches an `error`/`close` listener to the socket on the drain
+    // path, so a plain stub throws there. `readable` is load-bearing too — a
+    // non-readable socket reads as already finished and the body is skipped.
+    socket: Object.assign(new EventEmitter(), { encrypted: url.protocol === "https:", readable: true }),
   }) as unknown as IncomingMessage;
 
   message.once("end", () => {

--- a/packages/adapter-express/tests/connect-to-web.spec.ts
+++ b/packages/adapter-express/tests/connect-to-web.spec.ts
@@ -82,6 +82,28 @@ describe("connectToWeb (synthetic path) — body & basics", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ hello: "world" });
   });
+
+  it("answers 413 instead of crashing when a body parser drains an oversized body", async () => {
+    // body-parser dumps the unread body via on-finished, which attaches an
+    // error/close listener to req.socket — the stub must be a real EventEmitter.
+    const app = express();
+    app.use(express.json({ limit: 1 }));
+    app.post("/t", (req, res) => res.json(req.body));
+    app.use((_err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      res.status(413).end("too large");
+    });
+
+    const res = defined(
+      await connectToWeb(app)(
+        new Request("http://localhost/t", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ hello: "world, this exceeds one byte" }),
+        }),
+      ),
+    );
+    expect(res.status).toBe(413);
+  });
 });
 
 describe("connectToWeb (synthetic path) — Express connection metadata (socket stub)", () => {

--- a/packages/adapter-express/tests/node-forwarded.spec.ts
+++ b/packages/adapter-express/tests/node-forwarded.spec.ts
@@ -22,38 +22,27 @@ function fakeRes(): Any {
 }
 
 describe("createRequestAdapter — X-Forwarded-* resolution", () => {
-  // Proxies *append* to the forwarded headers, so the leftmost value is the one
-  // the client sent and the rightmost is the one the trusted proxy contributed.
-  // Reading left-to-right lets a client dictate the origin of `request.url`.
-  it("resolves X-Forwarded-Host from the trusted hop, not the client-supplied value", () => {
+  // For host/proto, `trustProxy` follows Express's `trust proxy`: the first value
+  // is the client-facing original, and the operator's proxy is trusted to set it
+  // (overwriting any client-supplied value). Later entries are inner hops.
+  it("reads the first X-Forwarded-Host — the public host, not an inner hop", () => {
     const adapter = createRequestAdapter({ trustProxy: true });
     const request = adapter(
-      fakeReq({
-        host: "real.example",
-        // "evil.test" was spoofed by the client; "real.example" was appended by
-        // the proxy we actually trust.
-        "x-forwarded-host": "evil.test, real.example",
-      }),
+      fakeReq({ host: "internal", "x-forwarded-host": "public.example, internal-lb:8080" }),
       fakeRes(),
     );
 
-    expect(new URL(request.url).host).toBe("real.example");
+    expect(new URL(request.url).host).toBe("public.example");
   });
 
-  it("resolves X-Forwarded-Proto from the trusted hop, not the client-supplied value", () => {
+  it("reads the first X-Forwarded-Proto — the client-facing scheme", () => {
     const adapter = createRequestAdapter({ trustProxy: true });
-    const request = adapter(
-      fakeReq({
-        host: "real.example",
-        "x-forwarded-proto": "https, http",
-      }),
-      fakeRes(),
-    );
+    const request = adapter(fakeReq({ host: "real.example", "x-forwarded-proto": "https, http" }), fakeRes());
 
-    expect(new URL(request.url).protocol).toBe("http:");
+    expect(new URL(request.url).protocol).toBe("https:");
   });
 
-  it("still honors a single forwarded value from the proxy", () => {
+  it("honors a single forwarded value from the proxy", () => {
     const adapter = createRequestAdapter({ trustProxy: true });
     const request = adapter(
       fakeReq({ host: "internal:8080", "x-forwarded-host": "public.example", "x-forwarded-proto": "https" }),
@@ -80,12 +69,12 @@ describe("createRequestAdapter — Forwarded (RFC 7239) resolution", () => {
     expect(request.url).toBe("https://public.example/p");
   });
 
-  it("reads the nearest (rightmost) element when the chain has several", () => {
+  it("reads the first element — the public host — when the chain has several", () => {
     const request = adapt({
       host: "internal",
-      forwarded: "host=evil.test;proto=http, host=real.example;proto=https",
+      forwarded: "host=public.example;proto=https, host=internal-lb:8080;proto=http",
     });
-    expect(request.url).toBe("https://real.example/p");
+    expect(request.url).toBe("https://public.example/p");
   });
 
   it("treats parameter names case-insensitively", () => {
@@ -94,7 +83,7 @@ describe("createRequestAdapter — Forwarded (RFC 7239) resolution", () => {
   });
 
   it("does not split on a comma inside a quoted value", () => {
-    // A quoted IPv6 `for` in the nearest element must not be read as two elements.
+    // A quoted IPv6 `for` in the first element must not be read as two elements.
     const request = adapt({ host: "internal", forwarded: 'for="[2001:db8::1]:4711";proto=https;host=public.example' });
     expect(request.url).toBe("https://public.example/p");
   });
@@ -104,20 +93,32 @@ describe("createRequestAdapter — Forwarded (RFC 7239) resolution", () => {
     expect(request.url).toBe("https://public.example:8443/p");
   });
 
-  it("falls back to the connection when the nearest element omits the param", () => {
-    // The nearest proxy set only `for`, so proto/host come from the socket and Host.
+  it("falls back to the connection when the first element omits the param", () => {
+    // Only `for` was set, so proto/host come from the socket and Host.
     const request = adapt({ host: "real.example", forwarded: "for=192.0.2.60" });
     expect(request.url).toBe("http://real.example/p");
   });
 
-  it("takes precedence over X-Forwarded-* and does not mix the two", () => {
+  it("only fills params that X-Forwarded-* leaves out, so a passed-through Forwarded cannot override the proxy", () => {
+    // The proxy set X-Forwarded-Host/Proto; a client `Forwarded` slipped through
+    // but must not win — X-Forwarded-* is authoritative per param.
     const request = adapt({
       host: "internal",
-      forwarded: "proto=https;host=from-forwarded.example",
-      "x-forwarded-host": "from-legacy.example",
-      "x-forwarded-proto": "http",
+      forwarded: "proto=https;host=evil.example",
+      "x-forwarded-host": "public.example",
+      "x-forwarded-proto": "https",
     });
-    expect(request.url).toBe("https://from-forwarded.example/p");
+    expect(request.url).toBe("https://public.example/p");
+  });
+
+  it("fills a param X-Forwarded-* omits", () => {
+    // X-Forwarded-Proto present, X-Forwarded-Host absent: host comes from Forwarded.
+    const request = adapt({
+      host: "internal",
+      forwarded: "host=public.example",
+      "x-forwarded-proto": "https",
+    });
+    expect(request.url).toBe("https://public.example/p");
   });
 
   it("is ignored entirely when trustProxy is off", () => {

--- a/packages/node/src/forwarded.ts
+++ b/packages/node/src/forwarded.ts
@@ -7,35 +7,30 @@ export function trustsProxy(): boolean {
 }
 
 /**
- * The `proto`/`host` contributed by the nearest proxy.
+ * The client-facing `proto`/`host`, matching Express's `trust proxy`: the first
+ * value, which is the original the client reached. `trustProxy` asserts the proxy
+ * sets these headers, overwriting any client-supplied one.
  *
- * RFC 7239's `Forwarded` is preferred over the older `X-Forwarded-*` when
- * present. Either way the nearest proxy is the rightmost entry, since proxies
- * append and the leftmost is whatever the client sent.
+ * `X-Forwarded-*` wins; RFC 7239's `Forwarded` fills a param the legacy header
+ * omits, so a client `Forwarded` passed through by a legacy proxy cannot override
+ * what that proxy set.
  */
 export function forwardedValue(headers: IncomingHttpHeaders, param: "proto" | "host"): string | undefined {
-  const forwarded = headers.forwarded;
-  // A trusted proxy that speaks `Forwarded` is authoritative: its element does
-  // not fall through to `X-Forwarded-*`, so one cannot be used to spoof the
-  // other. An absent param resolves from the connection instead.
-  if (forwarded) return nearestForwardedElement(String(forwarded))[param];
-
-  return rightmostListValue(headers[`x-forwarded-${param}`]);
+  return firstListValue(headers[`x-forwarded-${param}`]) ?? firstForwardedElement(headers.forwarded)[param];
 }
 
-function rightmostListValue(value: string | string[] | undefined): string | undefined {
+function firstListValue(value: string | string[] | undefined): string | undefined {
   if (!value) return undefined;
-  const hops = String(value).split(",");
-  return hops[hops.length - 1].trim() || undefined;
+  return String(value).split(",", 1)[0].trim() || undefined;
 }
 
-/** Parses the params (RFC 7239 §4) of the nearest — rightmost — element of a `Forwarded` header. */
-function nearestForwardedElement(header: string): { proto?: string; host?: string } {
-  const elements = splitOutsideQuotes(header, ",");
-  const nearest = elements[elements.length - 1];
-
+/** Parses the params (RFC 7239 §4) of the first element of a `Forwarded` header. */
+function firstForwardedElement(header: string | string[] | undefined): { proto?: string; host?: string } {
   const params: { proto?: string; host?: string } = {};
-  for (const pair of splitOutsideQuotes(nearest, ";")) {
+  if (!header) return params;
+
+  const [first] = splitOutsideQuotes(String(header), ",");
+  for (const pair of splitOutsideQuotes(first, ";")) {
     const eq = pair.indexOf("=");
     if (eq === -1) continue;
     const name = pair.slice(0, eq).trim().toLowerCase();

--- a/packages/node/src/request.ts
+++ b/packages/node/src/request.ts
@@ -45,13 +45,13 @@ export interface NodeRequestAdapterOptions {
    */
   origin?: string;
   /**
-   * Whether to trust the forwarding headers. The standard `Forwarded`
-   * header (RFC 7239) is used when present, otherwise `X-Forwarded-*`:
+   * Whether to trust the forwarding headers. `X-Forwarded-*` is used, with the
+   * standard `Forwarded` header (RFC 7239) filling any value it omits:
    * `proto`/`host` determine the origin when `origin` and
    * `process.env.ORIGIN` are not set, and `for` determines the IP address.
-   * The rightmost entry is used when several are present, as that is the
-   * one contributed by the nearest proxy. Defaults to true if
-   * `process.env.TRUST_PROXY` is set to `1`, otherwise false.
+   * The first entry is used when several are present, matching Express's
+   * `trust proxy` — it is the client-facing value the proxy set. Defaults to
+   * true if `process.env.TRUST_PROXY` is set to `1`, otherwise false.
    */
   trustProxy?: boolean;
 }

--- a/packages/node/src/response.ts
+++ b/packages/node/src/response.ts
@@ -53,7 +53,7 @@ export async function sendResponse(fetchResponse: Response, nodeResponse: Server
   // Node discards a HEAD body at the wire, and an endless one (SSE, a proxied
   // stream) would keep the response from ever finishing. The headers still
   // describe what a GET would have sent.
-  if (nodeResponse.req.method === "HEAD") {
+  if (nodeResponse.req?.method === "HEAD") {
     body?.destroy();
     nodeResponse.end();
     return;
@@ -72,9 +72,15 @@ export async function sendResponse(fetchResponse: Response, nodeResponse: Server
 
 // A client vanishing mid-response is routine; every other send failure is a real
 // bug worth surfacing rather than swallowing.
+const CLIENT_GONE_CODES = new Set([
+  "ECONNRESET",
+  "EPIPE",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ERR_STREAM_DESTROYED",
+  "ABORT_ERR",
+]);
 function isClientGone(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | undefined)?.code;
-  return code === "ECONNRESET" || code === "EPIPE" || code === "ERR_STREAM_PREMATURE_CLOSE";
+  return CLIENT_GONE_CODES.has((error as NodeJS.ErrnoException | undefined)?.code ?? "");
 }
 
 function getFullUrl(pathnameOrFull: string, req: IncomingMessage): string {
@@ -82,7 +88,9 @@ function getFullUrl(pathnameOrFull: string, req: IncomingMessage): string {
     return new URL(pathnameOrFull).href;
   } catch {
     // Without the opt-in, any client could set the header and point the redirect
-    // at a host of its choosing.
+    // at a host of its choosing. `responseAdapter` cannot see `createRequestAdapter`'s
+    // `trustProxy` option, so redirects honor only the `TRUST_PROXY` env var — set it
+    // to keep request.url and redirect origins consistent behind a proxy.
     const trustProxy = trustsProxy();
     const protocol =
       (trustProxy && forwardedValue(req.headers, "proto")) ||

--- a/packages/sirv/src/middleware.ts
+++ b/packages/sirv/src/middleware.ts
@@ -274,8 +274,9 @@ function revalidationHeaders(headers: Record<string, string>): Record<string, st
   return repeated;
 }
 
-/** Whether the client accepts one of `codings`. RFC 9110 §12.5.3: `*` matches any, an explicit coding overrides it, and a qvalue of 0 refuses. */
+/** Whether the client accepts one of `codings` (aliases of one encoding). RFC 9110 §12.5.3: `*` matches any, an explicit coding overrides it, a qvalue of 0 refuses. */
 function acceptsEncoding(header: string, codings: string[]): boolean {
+  let explicit: boolean | undefined;
   let wildcard: boolean | undefined;
   for (const entry of header.toLowerCase().split(",")) {
     const [coding, ...params] = entry.split(";");
@@ -289,10 +290,10 @@ function acceptsEncoding(header: string, codings: string[]): boolean {
       if (key.trim() === "q") acceptable = !(Number.parseFloat(value) <= 0);
     }
 
-    if (name !== "*") return acceptable;
-    wildcard = acceptable;
+    if (name === "*") wildcard = acceptable;
+    else explicit ||= acceptable; // codings are aliases, so any acceptable spelling accepts
   }
-  return wildcard ?? false;
+  return explicit ?? wildcard ?? false;
 }
 
 export default function serveStatic(dir?: string, opts: ServeOptions = {}): UniversalMiddleware {
@@ -302,10 +303,11 @@ export default function serveStatic(dir?: string, opts: ServeOptions = {}): Univ
   try {
     realDir = fs.realpathSync(dir);
   } catch (err) {
-    // Dev mode may be wired up before a watch/lazy build has created `dir`; defer
-    // to the per-request lookup, which 404s until it appears. Production still scans
-    // eagerly below, so a missing dir there stays an error.
-    if (!opts.dev) throw err;
+    // Dev mode may be wired up before a watch/lazy build has created `dir`; a
+    // genuinely missing dir defers to the per-request lookup (404s until it
+    // appears). Anything else — permissions, an invalid path — is a real
+    // misconfiguration, and production always resolves eagerly.
+    if (!opts.dev || (err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     realDir = dir;
   }
 

--- a/packages/sirv/src/middleware.ts
+++ b/packages/sirv/src/middleware.ts
@@ -171,7 +171,9 @@ function parseRange(header: string, size: number): { start: number; end: number 
     end = rawEnd === "" ? size - 1 : Math.min(Number.parseInt(rawEnd, 10), size - 1);
   }
 
-  return start > end ? "unsatisfiable" : { start, end };
+  if (start >= size) return "unsatisfiable"; // nothing to send past EOF → 416
+  if (start > end) return undefined; // backwards range (e.g. bytes=5-2) → ignore, serve 200 (RFC 9110 §14.2)
+  return { start, end };
 }
 
 const ENCODING: Record<string, string> = {
@@ -272,25 +274,40 @@ function revalidationHeaders(headers: Record<string, string>): Record<string, st
   return repeated;
 }
 
-/** Whether the client accepts one of `codings`. RFC 9110 §12.5.3: a qvalue of 0 means "not acceptable". */
+/** Whether the client accepts one of `codings`. RFC 9110 §12.5.3: `*` matches any, an explicit coding overrides it, and a qvalue of 0 refuses. */
 function acceptsEncoding(header: string, codings: string[]): boolean {
+  let wildcard: boolean | undefined;
   for (const entry of header.toLowerCase().split(",")) {
     const [coding, ...params] = entry.split(";");
-    if (!codings.includes(coding.trim())) continue;
+    const name = coding.trim();
+    if (name !== "*" && !codings.includes(name)) continue;
 
+    // A malformed or absent qvalue defaults to acceptable rather than refusing.
+    let acceptable = true;
     for (const param of params) {
       const [key, value] = param.split("=");
-      if (key.trim() === "q") return Number.parseFloat(value) > 0;
+      if (key.trim() === "q") acceptable = !(Number.parseFloat(value) <= 0);
     }
-    return true;
+
+    if (name !== "*") return acceptable;
+    wildcard = acceptable;
   }
-  return false;
+  return wildcard ?? false;
 }
 
 export default function serveStatic(dir?: string, opts: ServeOptions = {}): UniversalMiddleware {
   dir = resolve(dir || ".");
   // Resolved too, so that a symlinked root does not reject every file under it.
-  const realDir = fs.realpathSync(dir);
+  let realDir: string;
+  try {
+    realDir = fs.realpathSync(dir);
+  } catch (err) {
+    // Dev mode may be wired up before a watch/lazy build has created `dir`; defer
+    // to the per-request lookup, which 404s until it appears. Production still scans
+    // eagerly below, so a missing dir there stays an error.
+    if (!opts.dev) throw err;
+    realDir = dir;
+  }
 
   const isNotFound: OnNoMatch | undefined = opts.onNoMatch;
   const setHeaders: SetHeadersFunction = opts.setHeaders || noop;

--- a/packages/sirv/tests/encoding.spec.ts
+++ b/packages/sirv/tests/encoding.spec.ts
@@ -63,3 +63,44 @@ describe("accept-encoding :: q=0 is a refusal", () => {
     }
   });
 });
+
+describe("accept-encoding :: acceptable forms", () => {
+  test("should serve a variant for the `*` wildcard", async () => {
+    const server = utils.http({ gzip: true });
+
+    try {
+      const res = await server.send("GET", "/", { headers: { "Accept-Encoding": "*" } });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get("content-encoding"), "gzip");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should let an explicit `q=0` override a `*` wildcard", async () => {
+    const server = utils.http({ gzip: true });
+
+    try {
+      const res = await server.send("GET", "/", { headers: { "Accept-Encoding": "*, gzip;q=0" } });
+
+      assert.equal(res.status, 200);
+      assert.notOk(res.headers.get("content-encoding"));
+    } finally {
+      server.close();
+    }
+  });
+
+  test("should treat a valueless `q` as acceptable", async () => {
+    const server = utils.http({ gzip: true });
+
+    try {
+      const res = await server.send("GET", "/", { headers: { "Accept-Encoding": "gzip;q" } });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get("content-encoding"), "gzip");
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/packages/sirv/tests/encoding.spec.ts
+++ b/packages/sirv/tests/encoding.spec.ts
@@ -103,4 +103,18 @@ describe("accept-encoding :: acceptable forms", () => {
       server.close();
     }
   });
+
+  test("should accept an alias even when the primary spelling is refused", async () => {
+    // `x-gzip` is gzip under its legacy name; refusing `gzip` must not hide it.
+    const server = utils.http({ gzip: true });
+
+    try {
+      const res = await server.send("GET", "/", { headers: { "Accept-Encoding": "gzip;q=0, x-gzip" } });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get("content-encoding"), "gzip");
+    } finally {
+      server.close();
+    }
+  });
 });

--- a/packages/sirv/tests/ranges.spec.ts
+++ b/packages/sirv/tests/ranges.spec.ts
@@ -151,6 +151,23 @@ describe("ranges :: parsing", () => {
       server.close();
     }
   });
+
+  test("should ignore a backwards range and serve the full file", async () => {
+    const server = utils.http();
+
+    try {
+      const file = await utils.lookup("bundle.67329.js", "utf8");
+      // `bytes=5-2` is well-formed but last < first: RFC 9110 §14.2 ignores it,
+      // as opposed to `bytes=1000-` past EOF which is genuinely unsatisfiable (416).
+      const res = await utils.sendRaw(server.address, "GET", FILE, { Range: "bytes=5-2" });
+
+      assert.equal(res.status, 200);
+      assert.equal(res.headers["content-length"], String(file.size));
+      assert.equal(res.headers["content-range"], undefined);
+    } finally {
+      server.close();
+    }
+  });
 });
 
 describe("ranges :: advertising", () => {

--- a/packages/sirv/tests/sirv.spec.ts
+++ b/packages/sirv/tests/sirv.spec.ts
@@ -23,6 +23,10 @@ describe("types", () => {
   test("should throw error if `dir` is not found", () => {
     assert.throws(() => sirv("foobar"), /ENOENT/);
   });
+
+  test("should not throw for a missing `dir` in dev mode (build output may appear later)", () => {
+    assert.typeOf(sirv("foobar", { dev: true }), "function");
+  });
 });
 
 describe("basics", () => {

--- a/packages/sirv/tests/sirv.spec.ts
+++ b/packages/sirv/tests/sirv.spec.ts
@@ -27,6 +27,11 @@ describe("types", () => {
   test("should not throw for a missing `dir` in dev mode (build output may appear later)", () => {
     assert.typeOf(sirv("foobar", { dev: true }), "function");
   });
+
+  test("should still throw in dev mode when a path component is not a directory", () => {
+    // A non-ENOENT resolution failure is a real misconfiguration, not a not-yet-built dir.
+    assert.throws(() => sirv("package.json/assets", { dev: true }), /ENOTDIR/);
+  });
 });
 
 describe("basics", () => {


### PR DESCRIPTION
- express: the synthetic request socket is a real EventEmitter, so a body parser draining an oversized body (413) no longer crashes on `socket.on`.
- node: `X-Forwarded-*` is authoritative and read first-value (Express `trust proxy` semantics); RFC 7239 `Forwarded` only fills params the legacy header omits, so a passed-through client `Forwarded` cannot override the proxy. `isClientGone` also covers `ERR_STREAM_DESTROYED`/`ABORT_ERR`, and the HEAD check guards a possibly-absent `req`.
- sirv: a backwards range serves 200 instead of 416 (416 reserved for past-EOF); `Accept-Encoding` honors `*` and a valueless `q`; a missing dir in dev mode no longer throws at construction.
- node: documented that `responseAdapter` honors only the `TRUST_PROXY` env var, not `createRequestAdapter`'s `trustProxy` option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP range requests, including backwards ranges.
  * Improved `Accept-Encoding` wildcard and quality-value negotiation.
  * Missing static-file directories no longer cause errors in development mode.
  * Improved oversized-request handling and client disconnect detection.
  * Corrected forwarded host and protocol resolution to match proxy conventions.
  * Improved handling of `HEAD` requests and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->